### PR TITLE
feat: add deterministic parent-summary pipeline and critic checks (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Inductive explanation trees from Lean specifications (Verity -> Yul case study).
 ## Implemented slices
 - Issue #23: unified configuration contract with deterministic normalization, validation, hashing, cache keys, regeneration planning, and profile-key support.
 - Issue #11: OpenAI-compatible provider layer with deterministic retries, timeout handling, streaming SSE support, and typed error taxonomy.
+- Issue #8: parent-summary generation pipeline with strict structured-output schema, deterministic prompting, and critic validation diagnostics.
 
 ## Local checks
 ```bash
@@ -16,8 +17,10 @@ npm run build
 ## Live provider check
 ```bash
 EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live
+EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live:summary
 ```
 
 ## Spec docs
 - [Configuration contract](docs/config-contract.md)
 - [Provider layer](docs/openai-provider.md)
+- [Parent summary pipeline](docs/summary-pipeline.md)

--- a/docs/summary-pipeline.md
+++ b/docs/summary-pipeline.md
@@ -1,0 +1,52 @@
+# Parent Summary Pipeline (Issue #8)
+
+This module builds one parent node summary from a set of child nodes using the OpenAI-compatible provider layer, then enforces deterministic critic checks.
+
+## Core API
+- `generateParentSummary(provider, { children, config, systemPrompt? })`
+- `buildSummaryPromptMessages(children, config, systemPrompt?)`
+- `validateParentSummary(summary, children, config)`
+
+## Input Contract
+Each child must provide:
+- `id` (unique, non-empty)
+- `statement` (non-empty)
+- optional `complexity`
+
+Children are normalized and sorted by `id` before generation to keep prompt construction deterministic.
+
+## Required Model Output Schema
+```json
+{
+  "parent_statement": "string",
+  "why_true_from_children": "string",
+  "new_terms_introduced": ["string"],
+  "complexity_score": 1,
+  "abstraction_score": 1,
+  "evidence_refs": ["child_id"],
+  "confidence": 0.0
+}
+```
+
+## Critic Checks
+- Schema validity and numeric ranges.
+- `evidence_refs` must be non-empty and only cite provided child IDs.
+- `new_terms_introduced.length <= termIntroductionBudget`.
+- `complexity_score` must lie within
+  `[complexityLevel - complexityBandWidth, complexityLevel + complexityBandWidth]` (clamped to 1..5).
+- Unsupported term detection:
+  - Significant tokens in `parent_statement` are stem-normalized and compared against child + declared term tokens.
+  - If token coverage drops below a deterministic threshold, output is rejected as potential unsupported-claim drift.
+
+Failures raise `SummaryValidationError` with machine-readable `diagnostics`.
+
+## Determinism and Auditability
+- Prompt includes explicit config knobs (language, audience, complexity, abstraction, detail mode).
+- Generation runs with `temperature=0`.
+- Critic diagnostics enumerate exact failure codes and details.
+- JSON can be parsed from plain output or fenced code blocks.
+
+## Live Smoke Check
+```bash
+EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live:summary
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:live": "npm run -s build && node scripts/live-provider-check.mjs"
+    "test:live": "npm run -s build && node scripts/live-provider-check.mjs",
+    "test:live:summary": "npm run -s build && node scripts/live-summary-check.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.4.0",

--- a/scripts/live-summary-check.mjs
+++ b/scripts/live-summary-check.mjs
@@ -1,0 +1,74 @@
+import { DEFAULT_CONFIG, normalizeConfig } from "../dist/config-contract.js";
+import { createOpenAICompatibleProvider } from "../dist/openai-provider.js";
+import { generateParentSummary } from "../dist/summary-pipeline.js";
+
+const baseUrl = process.env.EXPLAIN_MD_LIVE_RPC_BASE_URL ?? "https://agent-backend.thomas.md/v1";
+const model = process.env.EXPLAIN_MD_LIVE_RPC_MODEL ?? "builtin/smart";
+const apiKey = process.env.EXPLAIN_MD_LIVE_RPC_API_KEY;
+const apiKeyEnvVar = "EXPLAIN_MD_LIVE_RPC_API_KEY";
+
+if (!apiKey) {
+  console.error(`Missing ${apiKeyEnvVar}. Refusing to run live summary check without explicit credentials.`);
+  process.exit(1);
+}
+
+const config = normalizeConfig({
+  language: "en",
+  complexityLevel: 3,
+  complexityBandWidth: 1,
+  termIntroductionBudget: 3,
+  modelProvider: {
+    ...DEFAULT_CONFIG.modelProvider,
+    endpoint: baseUrl,
+    model,
+    apiKeyEnvVar,
+    timeoutMs: 60_000,
+    maxRetries: 1,
+    retryBaseDelayMs: 250,
+    temperature: 0,
+    maxOutputTokens: 1400,
+  },
+});
+
+const provider = createOpenAICompatibleProvider({ config: config.modelProvider });
+
+try {
+  const result = await generateParentSummary(provider, {
+    config,
+    children: [
+      { id: "c1", statement: "Initialization establishes storage bounds for all tracked accounts." },
+      { id: "c2", statement: "Each update step preserves storage bounds and keeps account totals consistent." },
+      { id: "c3", statement: "Composed execution of bounded updates preserves the system invariant." },
+    ],
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: result.diagnostics.ok,
+        endpoint: baseUrl,
+        modelRequested: model,
+        evidenceRefs: result.summary.evidence_refs,
+        complexity: result.summary.complexity_score,
+        abstraction: result.summary.abstraction_score,
+        confidence: result.summary.confidence,
+      },
+      null,
+      2,
+    ),
+  );
+} catch (error) {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        endpoint: baseUrl,
+        modelRequested: model,
+        error: error instanceof Error ? { name: error.name, message: error.message } : String(error),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./config-contract.js";
 export * from "./openai-provider.js";
+export * from "./summary-pipeline.js";

--- a/src/summary-pipeline.ts
+++ b/src/summary-pipeline.ts
@@ -1,0 +1,430 @@
+import type { ExplanationConfig } from "./config-contract.js";
+import type { ChatMessage, ProviderClient } from "./openai-provider.js";
+
+export interface ChildNodeInput {
+  id: string;
+  statement: string;
+  complexity?: number;
+}
+
+export interface ParentSummary {
+  parent_statement: string;
+  why_true_from_children: string;
+  new_terms_introduced: string[];
+  complexity_score: number;
+  abstraction_score: number;
+  evidence_refs: string[];
+  confidence: number;
+}
+
+export interface CriticViolation {
+  code: "schema" | "evidence_refs" | "complexity_band" | "term_budget" | "unsupported_terms";
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface SummaryDiagnostics {
+  ok: boolean;
+  violations: CriticViolation[];
+}
+
+export interface SummaryPipelineRequest {
+  children: ChildNodeInput[];
+  config: ExplanationConfig;
+  systemPrompt?: string;
+}
+
+export interface SummaryPipelineResult {
+  summary: ParentSummary;
+  diagnostics: SummaryDiagnostics;
+  rawText: string;
+  raw: unknown;
+}
+
+export class SummaryValidationError extends Error {
+  public readonly diagnostics: SummaryDiagnostics;
+  public readonly rawText: string;
+
+  public constructor(message: string, diagnostics: SummaryDiagnostics, rawText: string) {
+    super(message);
+    this.name = "SummaryValidationError";
+    this.diagnostics = diagnostics;
+    this.rawText = rawText;
+  }
+}
+
+const STOP_WORDS = new Set<string>([
+  "about",
+  "after",
+  "again",
+  "because",
+  "before",
+  "being",
+  "between",
+  "could",
+  "every",
+  "first",
+  "from",
+  "have",
+  "into",
+  "their",
+  "there",
+  "these",
+  "those",
+  "through",
+  "under",
+  "using",
+  "where",
+  "which",
+  "while",
+  "with",
+  "without",
+]);
+
+const MIN_PARENT_TOKEN_COVERAGE = 0.45;
+const MIN_PARENT_TOKENS_FOR_COVERAGE_CHECK = 4;
+
+export async function generateParentSummary(
+  provider: ProviderClient,
+  request: SummaryPipelineRequest,
+): Promise<SummaryPipelineResult> {
+  const normalizedChildren = normalizeChildren(request.children);
+  const messages = buildSummaryPromptMessages(normalizedChildren, request.config, request.systemPrompt);
+
+  const generated = await provider.generate({
+    messages,
+    temperature: 0,
+    maxOutputTokens: request.config.modelProvider.maxOutputTokens,
+  });
+
+  const parsed = parseSummaryJson(generated.text);
+  const diagnostics = validateParentSummary(parsed, normalizedChildren, request.config);
+
+  if (!diagnostics.ok) {
+    throw new SummaryValidationError("Generated parent summary failed critic validation.", diagnostics, generated.text);
+  }
+
+  return {
+    summary: parsed,
+    diagnostics,
+    rawText: generated.text,
+    raw: generated.raw,
+  };
+}
+
+export function buildSummaryPromptMessages(
+  children: ChildNodeInput[],
+  config: ExplanationConfig,
+  systemPrompt?: string,
+): ChatMessage[] {
+  const childLines = children
+    .map((child) => {
+      const complexityTag = typeof child.complexity === "number" ? ` complexity=${child.complexity}` : "";
+      return `- id=${child.id}${complexityTag} statement=${JSON.stringify(child.statement)}`;
+    })
+    .join("\n");
+
+  const systemContent =
+    systemPrompt ??
+    "You are a proof-grounded summarizer. Output strict JSON only. Never cite evidence outside provided child IDs.";
+
+  const userContent = [
+    "Synthesize one parent explanation from child statements.",
+    "Return exactly one JSON object with this schema:",
+    '{"parent_statement":string,"why_true_from_children":string,"new_terms_introduced":string[],"complexity_score":number,"abstraction_score":number,"evidence_refs":string[],"confidence":number}',
+    "Constraints:",
+    `- language=${config.language}`,
+    `- target_complexity=${config.complexityLevel}`,
+    `- complexity_band_width=${config.complexityBandWidth}`,
+    `- target_abstraction=${config.abstractionLevel}`,
+    `- audience_level=${config.audienceLevel}`,
+    `- reading_level_target=${config.readingLevelTarget}`,
+    `- proof_detail_mode=${config.proofDetailMode}`,
+    `- term_introduction_budget=${config.termIntroductionBudget}`,
+    "- evidence_refs must only contain provided child IDs.",
+    "Children:",
+    childLines,
+  ].join("\n");
+
+  return [
+    { role: "system", content: systemContent },
+    { role: "user", content: userContent },
+  ];
+}
+
+export function validateParentSummary(
+  summary: ParentSummary,
+  children: ChildNodeInput[],
+  config: ExplanationConfig,
+): SummaryDiagnostics {
+  const violations: CriticViolation[] = [];
+
+  if (!summary.parent_statement || !summary.why_true_from_children) {
+    violations.push({
+      code: "schema",
+      message: "parent_statement and why_true_from_children are required non-empty strings.",
+    });
+  }
+
+  if (!Number.isFinite(summary.complexity_score) || summary.complexity_score < 1 || summary.complexity_score > 5) {
+    violations.push({
+      code: "schema",
+      message: "complexity_score must be a number in [1, 5].",
+    });
+  }
+
+  if (!Number.isFinite(summary.abstraction_score) || summary.abstraction_score < 1 || summary.abstraction_score > 5) {
+    violations.push({
+      code: "schema",
+      message: "abstraction_score must be a number in [1, 5].",
+    });
+  }
+
+  if (!Number.isFinite(summary.confidence) || summary.confidence < 0 || summary.confidence > 1) {
+    violations.push({
+      code: "schema",
+      message: "confidence must be a number in [0, 1].",
+    });
+  }
+
+  if (!Array.isArray(summary.new_terms_introduced) || !summary.new_terms_introduced.every((term) => typeof term === "string")) {
+    violations.push({
+      code: "schema",
+      message: "new_terms_introduced must be an array of strings.",
+    });
+  }
+
+  if (!Array.isArray(summary.evidence_refs) || !summary.evidence_refs.every((ref) => typeof ref === "string")) {
+    violations.push({
+      code: "schema",
+      message: "evidence_refs must be an array of strings.",
+    });
+  }
+
+  const childIds = new Set(children.map((child) => child.id));
+  const invalidRefs = summary.evidence_refs.filter((ref) => !childIds.has(ref));
+  if (invalidRefs.length > 0 || summary.evidence_refs.length === 0) {
+    violations.push({
+      code: "evidence_refs",
+      message: "evidence_refs must be non-empty and only include provided child IDs.",
+      details: { invalidRefs },
+    });
+  }
+
+  if (summary.new_terms_introduced.length > config.termIntroductionBudget) {
+    violations.push({
+      code: "term_budget",
+      message: "new_terms_introduced exceeded configured term introduction budget.",
+      details: {
+        introduced: summary.new_terms_introduced.length,
+        budget: config.termIntroductionBudget,
+      },
+    });
+  }
+
+  const minComplexity = Math.max(1, config.complexityLevel - config.complexityBandWidth);
+  const maxComplexity = Math.min(5, config.complexityLevel + config.complexityBandWidth);
+  if (summary.complexity_score < minComplexity || summary.complexity_score > maxComplexity) {
+    violations.push({
+      code: "complexity_band",
+      message: "complexity_score is outside configured complexity band.",
+      details: { target: config.complexityLevel, band: config.complexityBandWidth, value: summary.complexity_score },
+    });
+  }
+
+  const coverage = computeParentTokenCoverage(summary.parent_statement, children, summary.new_terms_introduced);
+  if (coverage.total >= MIN_PARENT_TOKENS_FOR_COVERAGE_CHECK && coverage.ratio < MIN_PARENT_TOKEN_COVERAGE) {
+    violations.push({
+      code: "unsupported_terms",
+      message: "parent_statement has low evidence-term coverage and may introduce unsupported claims.",
+      details: {
+        coverageRatio: coverage.ratio,
+        minimumRequired: MIN_PARENT_TOKEN_COVERAGE,
+        unsupported: coverage.unsupported,
+      },
+    });
+  }
+
+  return {
+    ok: violations.length === 0,
+    violations,
+  };
+}
+
+function normalizeChildren(children: ChildNodeInput[]): ChildNodeInput[] {
+  if (!Array.isArray(children) || children.length === 0) {
+    throw new Error("children must contain at least one node.");
+  }
+
+  const normalized = children.map((child) => {
+    const id = child.id.trim();
+    const statement = child.statement.trim();
+    if (!id || !statement) {
+      throw new Error("Each child requires non-empty id and statement.");
+    }
+    return {
+      id,
+      statement,
+      complexity: child.complexity,
+    };
+  });
+
+  const seen = new Set<string>();
+  for (const child of normalized) {
+    if (seen.has(child.id)) {
+      throw new Error(`Duplicate child id: ${child.id}`);
+    }
+    seen.add(child.id);
+  }
+
+  return normalized.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function parseSummaryJson(rawText: string): ParentSummary {
+  const candidate = extractFirstJsonObject(rawText);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    throw new SummaryValidationError(
+      "Failed to parse model output as JSON object.",
+      {
+        ok: false,
+        violations: [{ code: "schema", message: "Output was not valid JSON." }],
+      },
+      rawText,
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new SummaryValidationError(
+      "Parsed output must be an object.",
+      {
+        ok: false,
+        violations: [{ code: "schema", message: "Output JSON root must be an object." }],
+      },
+      rawText,
+    );
+  }
+
+  const candidateSummary = parsed as Partial<ParentSummary>;
+  return {
+    parent_statement: String(candidateSummary.parent_statement ?? "").trim(),
+    why_true_from_children: String(candidateSummary.why_true_from_children ?? "").trim(),
+    new_terms_introduced: Array.isArray(candidateSummary.new_terms_introduced)
+      ? candidateSummary.new_terms_introduced.map((value) => String(value).trim()).filter((value) => value.length > 0)
+      : [],
+    complexity_score: Number(candidateSummary.complexity_score),
+    abstraction_score: Number(candidateSummary.abstraction_score),
+    evidence_refs: Array.isArray(candidateSummary.evidence_refs)
+      ? candidateSummary.evidence_refs.map((value) => String(value).trim()).filter((value) => value.length > 0)
+      : [],
+    confidence: Number(candidateSummary.confidence),
+  };
+}
+
+function extractFirstJsonObject(rawText: string): string {
+  const trimmed = rawText.trim();
+  const codeFenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (codeFenceMatch) {
+    return codeFenceMatch[1].trim();
+  }
+
+  const firstBrace = trimmed.indexOf("{");
+  if (firstBrace === -1) {
+    return trimmed;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = firstBrace; index < trimmed.length; index += 1) {
+    const char = trimmed[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return trimmed.slice(firstBrace, index + 1);
+      }
+    }
+  }
+
+  return trimmed;
+}
+
+function computeParentTokenCoverage(
+  statement: string,
+  children: ChildNodeInput[],
+  introducedTerms: string[],
+): { ratio: number; total: number; unsupported: string[] } {
+  const childTokens = new Set(
+    children
+      .flatMap((child) => tokenize(child.statement).map(stemToken))
+      .filter((token) => token.length >= 4 && !STOP_WORDS.has(token)),
+  );
+  const introduced = new Set(introducedTerms.flatMap((term) => tokenize(term).map(stemToken)));
+
+  const significantTokens = tokenize(statement)
+    .map(stemToken)
+    .filter((token) => token.length >= 5 && !STOP_WORDS.has(token));
+  const unsupported = new Set<string>();
+  let covered = 0;
+  for (const token of significantTokens) {
+    if (childTokens.has(token) || introduced.has(token)) {
+      covered += 1;
+      continue;
+    }
+    unsupported.add(token);
+  }
+
+  const ratio = significantTokens.length === 0 ? 1 : covered / significantTokens.length;
+  return { ratio, total: significantTokens.length, unsupported: [...unsupported].sort() };
+}
+
+function stemToken(token: string): string {
+  if (token.endsWith("ies") && token.length > 5) {
+    return `${token.slice(0, -3)}y`;
+  }
+  if (token.endsWith("ing") && token.length > 6) {
+    return token.slice(0, -3);
+  }
+  if (token.endsWith("ed") && token.length > 5) {
+    return token.slice(0, -2);
+  }
+  if (token.endsWith("es") && token.length > 5) {
+    return token.slice(0, -2);
+  }
+  if (token.endsWith("s") && token.length > 4) {
+    return token.slice(0, -1);
+  }
+  return token;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/g)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}


### PR DESCRIPTION
## Summary
Implements the next high-leverage slice for issue #8: a deterministic parent-summary generation pipeline that sits on top of the OpenAI-compatible provider and enforces machine-checkable critic validation.

## What was implemented
- Added `src/summary-pipeline.ts`:
  - `generateParentSummary(provider, { children, config, systemPrompt? })`
  - deterministic child normalization/sorting
  - strict output parsing (plain JSON or fenced JSON)
  - structured output contract for parent summaries
  - critic checks for:
    - schema/range validity
    - evidence refs constrained to provided child IDs
    - complexity band compliance
    - term-introduction budget compliance
    - evidence-token coverage drift (unsupported-claim detector)
  - typed `SummaryValidationError` with machine-readable diagnostics
- Exported new module from `src/index.ts`
- Added tests in `tests/summary-pipeline.test.ts` covering success + reject paths
- Added docs `docs/summary-pipeline.md`
- Added live RPC smoke command `npm run test:live:summary` via `scripts/live-summary-check.mjs`
- Updated README with new implemented slice and checks

## Validation
- `npm test`
- `npm run build`
- `EXPLAIN_MD_LIVE_RPC_API_KEY=*** npm run test:live:summary`

All passed locally.

## What remains after this PR
- #7 child grouping algorithm and #9 recursive tree builder for full root synthesis.
- #25 pedagogy policy engine as a separate module between grouping and summarization.
- #18 evaluation harness to aggregate faithfulness/simplicity metrics over full trees.

## Why this advances the objective
This PR creates the first auditable parent-synthesis path with deterministic critic diagnostics, moving the project from provider primitives to a reusable explanation-node generation contract that can be plugged into grouping/recursive tree construction next.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new LLM-output parsing and validation logic plus a live RPC smoke check; mistakes could cause false rejections/acceptance of summaries and affect downstream synthesis quality.
> 
> **Overview**
> Adds a new `summary-pipeline` module that generates a single parent node summary from child statements with deterministic child normalization/sorting, deterministic prompting (`temperature=0`), JSON extraction/parsing (including fenced blocks), and a `SummaryValidationError` carrying machine-readable critic diagnostics.
> 
> Enforces critic checks for schema/range validity, `evidence_refs` restricted to provided child IDs, complexity-band and term-budget compliance, and a token-coverage heuristic to detect unsupported terms in the parent statement. Exposes the API via `src/index.ts`, adds focused Vitest coverage, documents the pipeline, and introduces `npm run test:live:summary` plus a new live smoke script; README updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69c15ec25d2f85a2ed383513569c36de877ee7d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->