### PR TITLE
feat(tree): add deterministic recursive single-root tree builder (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Inductive explanation trees from Lean specifications (Verity -> Yul case study).
 - Issue #23: unified configuration contract with deterministic normalization, validation, hashing, cache keys, regeneration planning, and profile-key support.
 - Issue #11: OpenAI-compatible provider layer with deterministic retries, timeout handling, streaming SSE support, and typed error taxonomy.
 - Issue #8: parent-summary generation pipeline with strict structured-output schema, deterministic prompting, and critic validation diagnostics.
+- Issue #9: recursive single-root tree builder with deterministic layering, structural validity checks, and leaf-preservation guarantees.
 
 ## Local checks
 ```bash
@@ -24,3 +25,4 @@ EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live:summary
 - [Configuration contract](docs/config-contract.md)
 - [Provider layer](docs/openai-provider.md)
 - [Parent summary pipeline](docs/summary-pipeline.md)
+- [Recursive tree builder](docs/tree-builder.md)

--- a/docs/tree-builder.md
+++ b/docs/tree-builder.md
@@ -1,0 +1,40 @@
+# Recursive tree builder
+
+Issue: #9
+
+## Scope
+- Build a single-root explanation tree from normalized leaf nodes.
+- Use deterministic layering with `maxChildrenPerParent` as a hard branching cap.
+- Generate each parent node through the validated parent-summary pipeline.
+- Validate structural invariants before returning the tree.
+
+## Deterministic behavior
+- Leaves are normalized and sorted by `id` before construction.
+- Layer grouping is stable left-to-right chunking by `maxChildrenPerParent`.
+- Parent IDs are deterministic hashes of `(depth, groupIndex, childIds)`.
+- Parent generation runs in deterministic request order.
+
+## Tree validity checks
+`validateExplanationTree` enforces:
+- A root exists in the node map.
+- All referenced child IDs resolve to known nodes.
+- All nodes are reachable from root (connected rooted DAG view).
+- Every declared leaf is reachable from root.
+- No parent exceeds `maxChildrenPerParent`.
+
+## Degenerate and boundary cases
+- One leaf: returns that leaf as root with depth `0`.
+- Very wide input sets: reduced layer-by-layer until one root remains.
+- Optional hard stop via `maxDepth` to avoid non-terminating behavior.
+
+## API
+- `buildRecursiveExplanationTree(provider, request)`
+- `validateExplanationTree(tree, maxChildrenPerParent)`
+
+Request shape:
+- `leaves`: `[{ id, statement, complexity? }]`
+- `config`: normalized `ExplanationConfig`
+- `maxDepth?`: optional explicit depth guard
+
+Output includes:
+- `rootId`, `leafIds`, `nodes`, `configHash`, `groupPlan`, `maxDepth`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./config-contract.js";
 export * from "./openai-provider.js";
 export * from "./summary-pipeline.js";
+export * from "./tree-builder.js";

--- a/src/tree-builder.ts
+++ b/src/tree-builder.ts
@@ -1,0 +1,303 @@
+import { createHash } from "node:crypto";
+import { computeConfigHash, type ExplanationConfig } from "./config-contract.js";
+import type { ProviderClient } from "./openai-provider.js";
+import { generateParentSummary } from "./summary-pipeline.js";
+
+export interface LeafNodeInput {
+  id: string;
+  statement: string;
+  complexity?: number;
+}
+
+export type ExplanationTreeNodeKind = "leaf" | "parent";
+
+export interface ExplanationTreeNode {
+  id: string;
+  kind: ExplanationTreeNodeKind;
+  statement: string;
+  childIds: string[];
+  depth: number;
+  complexityScore?: number;
+  abstractionScore?: number;
+  confidence?: number;
+  whyTrueFromChildren?: string;
+  newTermsIntroduced?: string[];
+  evidenceRefs: string[];
+}
+
+export interface GroupPlan {
+  depth: number;
+  index: number;
+  inputNodeIds: string[];
+  outputNodeId: string;
+}
+
+export interface ExplanationTree {
+  rootId: string;
+  leafIds: string[];
+  nodes: Record<string, ExplanationTreeNode>;
+  configHash: string;
+  groupPlan: GroupPlan[];
+  maxDepth: number;
+}
+
+export interface TreeBuildRequest {
+  leaves: LeafNodeInput[];
+  config: ExplanationConfig;
+  maxDepth?: number;
+}
+
+export interface TreeValidationIssue {
+  code: "missing_root" | "missing_node" | "not_connected" | "leaf_not_preserved" | "branching_factor";
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface TreeValidationResult {
+  ok: boolean;
+  issues: TreeValidationIssue[];
+}
+
+export async function buildRecursiveExplanationTree(
+  provider: ProviderClient,
+  request: TreeBuildRequest,
+): Promise<ExplanationTree> {
+  const leaves = normalizeLeaves(request.leaves);
+  const nodes: Record<string, ExplanationTreeNode> = {};
+  const leafIds = leaves.map((leaf) => leaf.id);
+  const groupPlan: GroupPlan[] = [];
+
+  for (const leaf of leaves) {
+    nodes[leaf.id] = {
+      id: leaf.id,
+      kind: "leaf",
+      statement: leaf.statement,
+      childIds: [],
+      depth: 0,
+      complexityScore: leaf.complexity,
+      evidenceRefs: [leaf.id],
+    };
+  }
+
+  if (leaves.length === 1) {
+    const tree: ExplanationTree = {
+      rootId: leaves[0].id,
+      leafIds,
+      nodes,
+      configHash: computeConfigHash(request.config),
+      groupPlan,
+      maxDepth: 0,
+    };
+
+    const validation = validateExplanationTree(tree, request.config.maxChildrenPerParent);
+    if (!validation.ok) {
+      throw new Error(`Tree validation failed: ${validation.issues.map((issue) => issue.code).join(", ")}`);
+    }
+
+    return tree;
+  }
+
+  const hardDepthLimit = request.maxDepth ?? computeDepthLimit(leaves.length, request.config.maxChildrenPerParent);
+
+  let depth = 0;
+  let activeNodeIds = leafIds.slice();
+
+  while (activeNodeIds.length > 1) {
+    depth += 1;
+    if (depth > hardDepthLimit) {
+      throw new Error(`Tree construction exceeded max depth ${hardDepthLimit}.`);
+    }
+
+    const groups = partitionNodeIds(activeNodeIds, request.config.maxChildrenPerParent);
+    const nextLayerIds: string[] = [];
+
+    for (let index = 0; index < groups.length; index += 1) {
+      const groupNodeIds = groups[index];
+      if (groupNodeIds.length === 1) {
+        nextLayerIds.push(groupNodeIds[0]);
+        continue;
+      }
+
+      const children = groupNodeIds.map((nodeId) => {
+        const node = nodes[nodeId];
+        return {
+          id: node.id,
+          statement: node.statement,
+          complexity: node.complexityScore,
+        };
+      });
+
+      const summaryResult = await generateParentSummary(provider, {
+        children,
+        config: request.config,
+      });
+
+      const parentId = buildParentNodeId(depth, index, groupNodeIds);
+      const parentNode: ExplanationTreeNode = {
+        id: parentId,
+        kind: "parent",
+        statement: summaryResult.summary.parent_statement,
+        childIds: groupNodeIds.slice(),
+        depth,
+        complexityScore: summaryResult.summary.complexity_score,
+        abstractionScore: summaryResult.summary.abstraction_score,
+        confidence: summaryResult.summary.confidence,
+        whyTrueFromChildren: summaryResult.summary.why_true_from_children,
+        newTermsIntroduced: summaryResult.summary.new_terms_introduced,
+        evidenceRefs: summaryResult.summary.evidence_refs,
+      };
+
+      nodes[parentId] = parentNode;
+      nextLayerIds.push(parentId);
+      groupPlan.push({ depth, index, inputNodeIds: groupNodeIds.slice(), outputNodeId: parentId });
+    }
+
+    activeNodeIds = nextLayerIds;
+  }
+
+  const tree: ExplanationTree = {
+    rootId: activeNodeIds[0],
+    leafIds,
+    nodes,
+    configHash: computeConfigHash(request.config),
+    groupPlan,
+    maxDepth: depth,
+  };
+
+  const validation = validateExplanationTree(tree, request.config.maxChildrenPerParent);
+  if (!validation.ok) {
+    throw new Error(`Tree validation failed: ${validation.issues.map((issue) => issue.code).join(", ")}`);
+  }
+
+  return tree;
+}
+
+export function validateExplanationTree(tree: ExplanationTree, maxChildrenPerParent: number): TreeValidationResult {
+  const issues: TreeValidationIssue[] = [];
+  const root = tree.nodes[tree.rootId];
+
+  if (!root) {
+    issues.push({ code: "missing_root", message: "Root node is missing from node map." });
+    return { ok: false, issues };
+  }
+
+  const reachable = new Set<string>();
+  const stack = [tree.rootId];
+
+  while (stack.length > 0) {
+    const nodeId = stack.pop() as string;
+    if (reachable.has(nodeId)) {
+      continue;
+    }
+
+    reachable.add(nodeId);
+    const node = tree.nodes[nodeId];
+    if (!node) {
+      issues.push({
+        code: "missing_node",
+        message: "Tree references a node ID that does not exist.",
+        details: { nodeId },
+      });
+      continue;
+    }
+
+    if (node.kind === "parent" && node.childIds.length > maxChildrenPerParent) {
+      issues.push({
+        code: "branching_factor",
+        message: "Parent node exceeds maxChildrenPerParent.",
+        details: { nodeId, childCount: node.childIds.length, maxChildrenPerParent },
+      });
+    }
+
+    for (const childId of node.childIds) {
+      stack.push(childId);
+    }
+  }
+
+  for (const nodeId of Object.keys(tree.nodes)) {
+    if (!reachable.has(nodeId)) {
+      issues.push({
+        code: "not_connected",
+        message: "Node is not reachable from root.",
+        details: { nodeId },
+      });
+    }
+  }
+
+  for (const leafId of tree.leafIds) {
+    if (!reachable.has(leafId)) {
+      issues.push({
+        code: "leaf_not_preserved",
+        message: "Leaf is not reachable from root.",
+        details: { leafId },
+      });
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}
+
+function normalizeLeaves(leaves: LeafNodeInput[]): LeafNodeInput[] {
+  if (!Array.isArray(leaves) || leaves.length === 0) {
+    throw new Error("leaves must contain at least one item.");
+  }
+
+  const normalized = leaves.map((leaf) => {
+    const id = leaf.id.trim();
+    const statement = leaf.statement.trim();
+    if (!id) {
+      throw new Error("leaf id must be non-empty.");
+    }
+    if (!statement) {
+      throw new Error(`leaf statement must be non-empty for id '${id}'.`);
+    }
+
+    if (leaf.complexity !== undefined && (!Number.isFinite(leaf.complexity) || leaf.complexity < 1 || leaf.complexity > 5)) {
+      throw new Error(`leaf complexity must be in [1, 5] for id '${id}'.`);
+    }
+
+    return {
+      id,
+      statement,
+      complexity: leaf.complexity,
+    };
+  });
+
+  normalized.sort((a, b) => a.id.localeCompare(b.id));
+
+  for (let i = 1; i < normalized.length; i += 1) {
+    if (normalized[i - 1].id === normalized[i].id) {
+      throw new Error(`leaf id must be unique: '${normalized[i].id}'.`);
+    }
+  }
+
+  return normalized;
+}
+
+function partitionNodeIds(nodeIds: string[], maxChildrenPerParent: number): string[][] {
+  const groups: string[][] = [];
+  for (let i = 0; i < nodeIds.length; i += maxChildrenPerParent) {
+    groups.push(nodeIds.slice(i, i + maxChildrenPerParent));
+  }
+  return groups;
+}
+
+function buildParentNodeId(depth: number, index: number, childIds: string[]): string {
+  const digest = createHash("sha256")
+    .update(`${depth}:${index}:${childIds.join(",")}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `p_${depth}_${index}_${digest}`;
+}
+
+function computeDepthLimit(leafCount: number, maxChildrenPerParent: number): number {
+  if (leafCount <= 1) {
+    return 0;
+  }
+
+  const base = Math.max(2, maxChildrenPerParent);
+  return Math.ceil(Math.log(leafCount) / Math.log(base)) + 2;
+}

--- a/tests/tree-builder.test.ts
+++ b/tests/tree-builder.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "vitest";
+import { normalizeConfig } from "../src/config-contract.js";
+import type { GenerateRequest, GenerateResult, ProviderClient } from "../src/openai-provider.js";
+import {
+  buildRecursiveExplanationTree,
+  validateExplanationTree,
+  type ExplanationTree,
+} from "../src/tree-builder.js";
+
+describe("tree builder", () => {
+  test("builds a connected rooted tree from wide leaf set", async () => {
+    const config = normalizeConfig({ maxChildrenPerParent: 3, complexityLevel: 3, complexityBandWidth: 2 });
+
+    const tree = await buildRecursiveExplanationTree(deterministicSummaryProvider(), {
+      config,
+      leaves: [
+        { id: "l5", statement: "Fifth theorem preserves state." },
+        { id: "l1", statement: "First theorem establishes invariant." },
+        { id: "l3", statement: "Third theorem composes transition relation." },
+        { id: "l2", statement: "Second theorem preserves invariant." },
+        { id: "l4", statement: "Fourth theorem links transition and invariant." },
+      ],
+    });
+
+    expect(tree.rootId).toMatch(/^p_/);
+    expect(tree.leafIds).toEqual(["l1", "l2", "l3", "l4", "l5"]);
+    expect(tree.maxDepth).toBeGreaterThan(0);
+
+    const validation = validateExplanationTree(tree, config.maxChildrenPerParent);
+    expect(validation.ok).toBe(true);
+
+    const parentNodes = Object.values(tree.nodes).filter((node) => node.kind === "parent");
+    expect(parentNodes.length).toBeGreaterThan(0);
+    expect(parentNodes.every((node) => node.childIds.length <= 3)).toBe(true);
+  });
+
+  test("handles degenerate case with exactly one leaf", async () => {
+    const config = normalizeConfig({});
+
+    const tree = await buildRecursiveExplanationTree(deterministicSummaryProvider(), {
+      config,
+      leaves: [{ id: "l1", statement: "Only theorem." }],
+    });
+
+    expect(tree.rootId).toBe("l1");
+    expect(tree.maxDepth).toBe(0);
+    expect(tree.groupPlan).toHaveLength(0);
+
+    const validation = validateExplanationTree(tree, config.maxChildrenPerParent);
+    expect(validation.ok).toBe(true);
+  });
+
+  test("is deterministic for same leaves and config", async () => {
+    const config = normalizeConfig({ maxChildrenPerParent: 2, complexityLevel: 3, complexityBandWidth: 2 });
+
+    const first = await buildRecursiveExplanationTree(deterministicSummaryProvider(), {
+      config,
+      leaves: [
+        { id: "b", statement: "B statement." },
+        { id: "a", statement: "A statement." },
+        { id: "c", statement: "C statement." },
+      ],
+    });
+
+    const second = await buildRecursiveExplanationTree(deterministicSummaryProvider(), {
+      config,
+      leaves: [
+        { id: "c", statement: "C statement." },
+        { id: "a", statement: "A statement." },
+        { id: "b", statement: "B statement." },
+      ],
+    });
+
+    expect(first.rootId).toBe(second.rootId);
+    expect(first.groupPlan).toEqual(second.groupPlan);
+    expect(first.nodes[first.rootId].statement).toBe(second.nodes[second.rootId].statement);
+  });
+
+  test("validator reports disconnected leaves", () => {
+    const tree: ExplanationTree = {
+      rootId: "p1",
+      leafIds: ["l1", "l2"],
+      configHash: "hash",
+      groupPlan: [],
+      maxDepth: 1,
+      nodes: {
+        p1: {
+          id: "p1",
+          kind: "parent",
+          statement: "root",
+          childIds: ["l1"],
+          depth: 1,
+          evidenceRefs: ["l1"],
+        },
+        l1: {
+          id: "l1",
+          kind: "leaf",
+          statement: "leaf one",
+          childIds: [],
+          depth: 0,
+          evidenceRefs: ["l1"],
+        },
+        l2: {
+          id: "l2",
+          kind: "leaf",
+          statement: "leaf two",
+          childIds: [],
+          depth: 0,
+          evidenceRefs: ["l2"],
+        },
+      },
+    };
+
+    const validation = validateExplanationTree(tree, 5);
+    expect(validation.ok).toBe(false);
+    expect(validation.issues.map((issue) => issue.code)).toContain("leaf_not_preserved");
+    expect(validation.issues.map((issue) => issue.code)).toContain("not_connected");
+  });
+});
+
+function deterministicSummaryProvider(): ProviderClient {
+  return {
+    generate: async (request: GenerateRequest): Promise<GenerateResult> => {
+      const childIds = extractChildIds(request);
+      const parentStatement = `Parent(${childIds.join("+")})`;
+
+      return {
+        text: JSON.stringify({
+          parent_statement: parentStatement,
+          why_true_from_children: `${childIds.join(", ")} jointly entail the parent claim.`,
+          new_terms_introduced: [],
+          complexity_score: 3,
+          abstraction_score: 3,
+          evidence_refs: childIds,
+          confidence: 0.9,
+        }),
+        model: "mock",
+        finishReason: "stop",
+        raw: {},
+      };
+    },
+    stream: async function* () {
+      return;
+    },
+  };
+}
+
+function extractChildIds(request: GenerateRequest): string[] {
+  const prompt = request.messages[1]?.content ?? "";
+  const matches = [...prompt.matchAll(/id=([^\s]+)/g)];
+  return matches.map((match) => match[1]).sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
## Summary
Implements issue #9 with a deterministic recursive builder that reduces leaves to a single rooted explanation tree using the existing parent-summary pipeline.

## What was implemented
- Added `buildRecursiveExplanationTree` in `src/tree-builder.ts`.
- Added deterministic normalization/grouping/parent-id derivation.
- Added structural validity checks via `validateExplanationTree`:
  - root exists
  - all referenced nodes exist
  - graph is connected from root
  - all leaves preserved/reachable
  - branching cap enforced
- Added tree diagnostics metadata (`groupPlan`, `maxDepth`, `configHash`) for auditability.
- Added tests for:
  - wide input sets and branching cap
  - degenerate one-leaf case
  - deterministic replay with reordered input
  - disconnected leaf detection
- Added docs: `docs/tree-builder.md` and README updates.

## Validation
- `npm test` -> 24/24 passing
- `npm run build` -> passing

## Remaining work after this PR
- Issue #7: replace current deterministic chunking with dependency+semantic grouping.
- Issue #5: map full Lean leaf provenance schema into builder input/output nodes.
- Issue #17: connect root/leaf nodes to browser-triggered proof verification flow.

## Why this advances the objective
This is the first end-to-end deterministic assembly layer from validated parent summaries to one auditable root while preserving reachability of every proof leaf.

Closes #9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new async tree-construction pipeline that calls the LLM summary generator iteratively and enforces structural validation; failures now surface as runtime errors during construction/validation. Risk is contained to the new exported API but includes determinism/ID hashing and depth-limit logic that could affect callers’ expectations.
> 
> **Overview**
> Adds a deterministic recursive tree builder (`buildRecursiveExplanationTree`) that reduces normalized/sorted leaf nodes into a single-root explanation tree by chunking to `maxChildrenPerParent` and generating parent nodes via `generateParentSummary`, with deterministic hashed parent IDs plus audit metadata (`groupPlan`, `configHash`, `maxDepth`).
> 
> Introduces `validateExplanationTree` to enforce root presence, referential integrity, connectivity/reachability (including leaf preservation), and branching-factor caps; the builder now throws if validation fails or a depth guard is exceeded. Exposes the new module from `src/index.ts`, adds focused Vitest coverage, and documents the new slice in `README.md` + `docs/tree-builder.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2ce77cd4c27876abfb94cb2bbc359ffb60f1a4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->