### PR TITLE
feat(grouping): deterministic inductive child grouping with provenance diagnostics (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Inductive explanation trees from Lean specifications (Verity -> Yul case study).
 ## Implemented slices
 - Issue #23: unified configuration contract with deterministic normalization, validation, hashing, cache keys, regeneration planning, and profile-key support.
 - Issue #11: OpenAI-compatible provider layer with deterministic retries, timeout handling, streaming SSE support, and typed error taxonomy.
+- Issue #7: inductive child-grouping algorithm with deterministic prerequisite-aware scheduling and complexity-bounded sibling partitioning.
 - Issue #8: parent-summary generation pipeline with strict structured-output schema, deterministic prompting, and critic validation diagnostics.
 - Issue #9: recursive single-root tree builder with deterministic layering, structural validity checks, and leaf-preservation guarantees.
 
@@ -24,5 +25,6 @@ EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live:summary
 ## Spec docs
 - [Configuration contract](docs/config-contract.md)
 - [Provider layer](docs/openai-provider.md)
+- [Inductive child grouping](docs/child-grouping.md)
 - [Parent summary pipeline](docs/summary-pipeline.md)
 - [Recursive tree builder](docs/tree-builder.md)

--- a/docs/child-grouping.md
+++ b/docs/child-grouping.md
@@ -1,0 +1,43 @@
+# Inductive child grouping
+
+Issue: #7
+
+## Scope
+- Deterministically group child nodes before parent-summary synthesis.
+- Respect hard branching cap (`maxChildrenPerParent`).
+- Enforce sibling complexity spread bound from config (`complexityBandWidth`).
+- Preserve prerequisite ordering using stable topological scheduling.
+
+## Algorithm
+1. Normalize nodes (trim, validate, sort by `id`, deduplicate prerequisites).
+2. Compute deterministic topological order from `prerequisiteIds`.
+3. Build each group greedily from that order with these constraints:
+   - prerequisites for each added node must already be assigned or inside the same group,
+   - resulting group size must stay `<= maxChildrenPerParent`,
+   - resulting complexity spread (`max - min`) must stay `<= complexityBandWidth`.
+4. Resolve candidate ties using deterministic score ordering:
+   - higher semantic token overlap with current group,
+   - lower complexity delta,
+   - lower target-complexity delta,
+   - earlier topological order.
+
+## Determinism and provenance
+- Same inputs/config always produce the same `groups` and `orderedNodeIds`.
+- Diagnostics include complexity spread per group and explicit warnings:
+  - `missing_complexity`: complexity defaulted to target complexity.
+  - `cycle_detected`: prerequisite cycle fallback used lexical order.
+
+## API
+- `groupChildrenDeterministically(request)`
+
+Request fields:
+- `nodes`: `[{ id, statement, complexity?, prerequisiteIds? }]`
+- `maxChildrenPerParent`: integer `>= 2`
+- `targetComplexity`: number in `[1, 5]`
+- `complexityBandWidth`: integer in `[0, 3]`
+
+Response fields:
+- `groups`: ordered array of child-id arrays
+- `diagnostics.orderedNodeIds`: deterministic topological order
+- `diagnostics.complexitySpreadByGroup`: per-group spread
+- `diagnostics.warnings`: machine-checkable fallbacks

--- a/docs/tree-builder.md
+++ b/docs/tree-builder.md
@@ -4,15 +4,16 @@ Issue: #9
 
 ## Scope
 - Build a single-root explanation tree from normalized leaf nodes.
-- Use deterministic layering with `maxChildrenPerParent` as a hard branching cap.
+- Use deterministic inductive grouping with `maxChildrenPerParent` as a hard branching cap.
 - Generate each parent node through the validated parent-summary pipeline.
 - Validate structural invariants before returning the tree.
 
 ## Deterministic behavior
 - Leaves are normalized and sorted by `id` before construction.
-- Layer grouping is stable left-to-right chunking by `maxChildrenPerParent`.
+- Layer grouping uses the `child-grouping` planner (stable topological ordering + deterministic candidate scoring).
 - Parent IDs are deterministic hashes of `(depth, groupIndex, childIds)`.
 - Parent generation runs in deterministic request order.
+- Grouping diagnostics are preserved per depth for auditability.
 
 ## Tree validity checks
 `validateExplanationTree` enforces:
@@ -37,4 +38,4 @@ Request shape:
 - `maxDepth?`: optional explicit depth guard
 
 Output includes:
-- `rootId`, `leafIds`, `nodes`, `configHash`, `groupPlan`, `maxDepth`
+- `rootId`, `leafIds`, `nodes`, `configHash`, `groupPlan`, `groupingDiagnostics`, `maxDepth`

--- a/src/child-grouping.ts
+++ b/src/child-grouping.ts
@@ -1,0 +1,345 @@
+import { createHash } from "node:crypto";
+
+export interface GroupingNodeInput {
+  id: string;
+  statement: string;
+  complexity?: number;
+  prerequisiteIds?: string[];
+}
+
+export interface GroupingRequest {
+  nodes: GroupingNodeInput[];
+  maxChildrenPerParent: number;
+  targetComplexity: number;
+  complexityBandWidth: number;
+}
+
+export interface GroupingWarning {
+  code: "cycle_detected" | "missing_complexity";
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface GroupingDiagnostics {
+  orderedNodeIds: string[];
+  complexitySpreadByGroup: number[];
+  warnings: GroupingWarning[];
+}
+
+export interface GroupingResult {
+  groups: string[][];
+  diagnostics: GroupingDiagnostics;
+}
+
+const TOKEN_STOP_WORDS = new Set<string>([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "be",
+  "by",
+  "for",
+  "from",
+  "in",
+  "is",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "to",
+  "with",
+]);
+
+export function groupChildrenDeterministically(request: GroupingRequest): GroupingResult {
+  const nodes = normalizeNodes(request.nodes);
+  if (!Number.isInteger(request.maxChildrenPerParent) || request.maxChildrenPerParent < 2) {
+    throw new Error("maxChildrenPerParent must be an integer >= 2.");
+  }
+  if (!Number.isFinite(request.targetComplexity) || request.targetComplexity < 1 || request.targetComplexity > 5) {
+    throw new Error("targetComplexity must be in [1, 5].");
+  }
+  if (!Number.isInteger(request.complexityBandWidth) || request.complexityBandWidth < 0 || request.complexityBandWidth > 3) {
+    throw new Error("complexityBandWidth must be an integer in [0, 3].");
+  }
+
+  const warnings: GroupingWarning[] = [];
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  const tokenMap = new Map(nodes.map((node) => [node.id, tokenize(node.statement)]));
+
+  const missingComplexityIds = nodes.filter((node) => node.complexity === undefined).map((node) => node.id);
+  if (missingComplexityIds.length > 0) {
+    warnings.push({
+      code: "missing_complexity",
+      message: "Missing complexities were replaced with targetComplexity for deterministic grouping.",
+      details: { nodeIds: missingComplexityIds, fallbackComplexity: request.targetComplexity },
+    });
+  }
+
+  const topoResult = stableTopologicalOrder(nodes);
+  warnings.push(...topoResult.warnings);
+
+  const groups: string[][] = [];
+  const assigned = new Set<string>();
+
+  for (const seedId of topoResult.orderedIds) {
+    if (assigned.has(seedId)) {
+      continue;
+    }
+
+    const group: string[] = [seedId];
+    assigned.add(seedId);
+
+    while (group.length < request.maxChildrenPerParent) {
+      const candidates = topoResult.orderedIds.filter((candidateId) => {
+        if (assigned.has(candidateId)) {
+          return false;
+        }
+
+        const node = nodeMap.get(candidateId) as GroupingNodeInput;
+        const prerequisites = (node.prerequisiteIds ?? []).filter((prereqId) => nodeMap.has(prereqId));
+        return prerequisites.every((prereqId) => assigned.has(prereqId) || group.includes(prereqId));
+      });
+
+      if (candidates.length === 0) {
+        break;
+      }
+
+      const viableCandidates = candidates.filter((candidateId) => {
+        const complexities = [...group, candidateId].map((nodeId) => resolveComplexity(nodeMap.get(nodeId), request.targetComplexity));
+        return computeComplexitySpread(complexities) <= request.complexityBandWidth;
+      });
+
+      if (viableCandidates.length === 0) {
+        break;
+      }
+
+      const chosenCandidate = chooseCandidate(viableCandidates, group, nodeMap, tokenMap, topoResult.orderIndex, request.targetComplexity);
+      group.push(chosenCandidate);
+      assigned.add(chosenCandidate);
+    }
+
+    groups.push(group);
+  }
+
+  const complexitySpreadByGroup = groups.map((group) => {
+    const complexities = group.map((nodeId) => resolveComplexity(nodeMap.get(nodeId), request.targetComplexity));
+    return computeComplexitySpread(complexities);
+  });
+
+  return {
+    groups,
+    diagnostics: {
+      orderedNodeIds: topoResult.orderedIds,
+      complexitySpreadByGroup,
+      warnings,
+    },
+  };
+}
+
+interface TopologicalResult {
+  orderedIds: string[];
+  orderIndex: Map<string, number>;
+  warnings: GroupingWarning[];
+}
+
+function stableTopologicalOrder(nodes: GroupingNodeInput[]): TopologicalResult {
+  const nodeIds = nodes.map((node) => node.id);
+  const nodeSet = new Set(nodeIds);
+  const inDegree = new Map<string, number>(nodeIds.map((id) => [id, 0]));
+  const outgoing = new Map<string, string[]>(nodeIds.map((id) => [id, []]));
+
+  for (const node of nodes) {
+    const prerequisites = (node.prerequisiteIds ?? []).filter((prereqId) => nodeSet.has(prereqId));
+    for (const prerequisiteId of prerequisites) {
+      inDegree.set(node.id, (inDegree.get(node.id) as number) + 1);
+      (outgoing.get(prerequisiteId) as string[]).push(node.id);
+    }
+  }
+
+  const ready = nodeIds.filter((id) => (inDegree.get(id) as number) === 0).sort((a, b) => a.localeCompare(b));
+  const orderedIds: string[] = [];
+
+  while (ready.length > 0) {
+    const id = ready.shift() as string;
+    orderedIds.push(id);
+
+    const dependents = (outgoing.get(id) as string[]).slice().sort((a, b) => a.localeCompare(b));
+    for (const dependentId of dependents) {
+      inDegree.set(dependentId, (inDegree.get(dependentId) as number) - 1);
+      if (inDegree.get(dependentId) === 0) {
+        insertSorted(ready, dependentId);
+      }
+    }
+  }
+
+  const warnings: GroupingWarning[] = [];
+  if (orderedIds.length !== nodeIds.length) {
+    const unresolved = nodeIds.filter((id) => !orderedIds.includes(id)).sort((a, b) => a.localeCompare(b));
+    warnings.push({
+      code: "cycle_detected",
+      message: "Prerequisite cycle detected. Falling back to lexical order for unresolved nodes.",
+      details: { unresolvedNodeIds: unresolved },
+    });
+    orderedIds.push(...unresolved);
+  }
+
+  const orderIndex = new Map<string, number>();
+  for (let index = 0; index < orderedIds.length; index += 1) {
+    orderIndex.set(orderedIds[index], index);
+  }
+
+  return { orderedIds, orderIndex, warnings };
+}
+
+function chooseCandidate(
+  candidateIds: string[],
+  group: string[],
+  nodeMap: Map<string, GroupingNodeInput>,
+  tokenMap: Map<string, Set<string>>,
+  orderIndex: Map<string, number>,
+  targetComplexity: number,
+): string {
+  const groupComplexities = group.map((id) => resolveComplexity(nodeMap.get(id), targetComplexity));
+  const groupAverageComplexity = average(groupComplexities);
+
+  const scored = candidateIds.map((candidateId) => {
+    const candidateTokens = tokenMap.get(candidateId) as Set<string>;
+    const complexity = resolveComplexity(nodeMap.get(candidateId), targetComplexity);
+
+    let bestSemantic = 0;
+    for (const groupId of group) {
+      const similarity = jaccardSimilarity(candidateTokens, tokenMap.get(groupId) as Set<string>);
+      if (similarity > bestSemantic) {
+        bestSemantic = similarity;
+      }
+    }
+
+    return {
+      id: candidateId,
+      semanticScore: bestSemantic,
+      complexityDelta: Math.abs(complexity - groupAverageComplexity),
+      targetDelta: Math.abs(complexity - targetComplexity),
+      order: orderIndex.get(candidateId) as number,
+      tieBreakHash: stableHash(candidateId),
+    };
+  });
+
+  scored.sort((a, b) => {
+    if (b.semanticScore !== a.semanticScore) {
+      return b.semanticScore - a.semanticScore;
+    }
+    if (a.complexityDelta !== b.complexityDelta) {
+      return a.complexityDelta - b.complexityDelta;
+    }
+    if (a.targetDelta !== b.targetDelta) {
+      return a.targetDelta - b.targetDelta;
+    }
+    if (a.order !== b.order) {
+      return a.order - b.order;
+    }
+    return a.tieBreakHash.localeCompare(b.tieBreakHash);
+  });
+
+  return scored[0].id;
+}
+
+function normalizeNodes(nodes: GroupingNodeInput[]): GroupingNodeInput[] {
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    throw new Error("nodes must contain at least one item.");
+  }
+
+  const normalized = nodes.map((node) => {
+    const id = node.id.trim();
+    const statement = node.statement.trim();
+    if (!id) {
+      throw new Error("node id must be non-empty.");
+    }
+    if (!statement) {
+      throw new Error(`node statement must be non-empty for id '${id}'.`);
+    }
+
+    if (node.complexity !== undefined && (!Number.isFinite(node.complexity) || node.complexity < 1 || node.complexity > 5)) {
+      throw new Error(`node complexity must be in [1, 5] for id '${id}'.`);
+    }
+
+    return {
+      id,
+      statement,
+      complexity: node.complexity,
+      prerequisiteIds: unique((node.prerequisiteIds ?? []).map((value) => value.trim()).filter((value) => value.length > 0)),
+    } satisfies GroupingNodeInput;
+  });
+
+  normalized.sort((a, b) => a.id.localeCompare(b.id));
+
+  for (let index = 1; index < normalized.length; index += 1) {
+    if (normalized[index - 1].id === normalized[index].id) {
+      throw new Error(`node id must be unique: '${normalized[index].id}'.`);
+    }
+  }
+
+  return normalized;
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function tokenize(statement: string): Set<string> {
+  const tokens = statement
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/g)
+    .map((value) => value.trim())
+    .filter((value) => value.length >= 3)
+    .filter((value) => !TOKEN_STOP_WORDS.has(value));
+  return new Set(tokens);
+}
+
+function jaccardSimilarity(left: Set<string>, right: Set<string>): number {
+  if (left.size === 0 || right.size === 0) {
+    return 0;
+  }
+
+  let intersection = 0;
+  for (const token of left) {
+    if (right.has(token)) {
+      intersection += 1;
+    }
+  }
+
+  const union = left.size + right.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function resolveComplexity(node: GroupingNodeInput | undefined, fallback: number): number {
+  return node?.complexity ?? fallback;
+}
+
+function computeComplexitySpread(values: number[]): number {
+  if (values.length <= 1) {
+    return 0;
+  }
+  return Math.max(...values) - Math.min(...values);
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sum = values.reduce((total, value) => total + value, 0);
+  return sum / values.length;
+}
+
+function insertSorted(values: string[], value: string): void {
+  let index = 0;
+  while (index < values.length && values[index].localeCompare(value) < 0) {
+    index += 1;
+  }
+  values.splice(index, 0, value);
+}
+
+function stableHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./config-contract.js";
+export * from "./child-grouping.js";
 export * from "./openai-provider.js";
 export * from "./summary-pipeline.js";
 export * from "./tree-builder.js";

--- a/tests/child-grouping.test.ts
+++ b/tests/child-grouping.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import { groupChildrenDeterministically } from "../src/child-grouping.js";
+
+describe("child grouping", () => {
+  test("is deterministic across input ordering", () => {
+    const request = {
+      maxChildrenPerParent: 2,
+      targetComplexity: 3,
+      complexityBandWidth: 1,
+      nodes: [
+        { id: "c", statement: "Bounded transfer preserves storage invariant.", complexity: 3 },
+        { id: "a", statement: "Initialization establishes storage invariant.", complexity: 2 },
+        { id: "b", statement: "Transfer preserves storage invariant.", complexity: 3, prerequisiteIds: ["a"] },
+        { id: "d", statement: "Withdrawal preserves storage invariant.", complexity: 4, prerequisiteIds: ["a"] },
+      ],
+    };
+
+    const first = groupChildrenDeterministically(request);
+    const second = groupChildrenDeterministically({
+      ...request,
+      nodes: request.nodes.slice().reverse(),
+    });
+
+    expect(first.groups).toEqual(second.groups);
+    expect(first.diagnostics.orderedNodeIds).toEqual(second.diagnostics.orderedNodeIds);
+  });
+
+  test("respects prerequisite ordering in topological schedule", () => {
+    const result = groupChildrenDeterministically({
+      maxChildrenPerParent: 3,
+      targetComplexity: 3,
+      complexityBandWidth: 2,
+      nodes: [
+        { id: "lemma_c", statement: "C depends on B.", complexity: 3, prerequisiteIds: ["lemma_b"] },
+        { id: "lemma_a", statement: "A is base case.", complexity: 2 },
+        { id: "lemma_b", statement: "B depends on A.", complexity: 3, prerequisiteIds: ["lemma_a"] },
+      ],
+    });
+
+    const order = result.diagnostics.orderedNodeIds;
+    expect(order.indexOf("lemma_a")).toBeLessThan(order.indexOf("lemma_b"));
+    expect(order.indexOf("lemma_b")).toBeLessThan(order.indexOf("lemma_c"));
+  });
+
+  test("enforces max children and complexity spread bound", () => {
+    const result = groupChildrenDeterministically({
+      maxChildrenPerParent: 4,
+      targetComplexity: 3,
+      complexityBandWidth: 1,
+      nodes: [
+        { id: "l1", statement: "Low complexity base lemma.", complexity: 1 },
+        { id: "l2", statement: "Low complexity preservation lemma.", complexity: 2 },
+        { id: "h1", statement: "High complexity compositional theorem.", complexity: 4 },
+        { id: "h2", statement: "High complexity refinement theorem.", complexity: 5 },
+      ],
+    });
+
+    expect(result.groups.every((group) => group.length <= 4)).toBe(true);
+    expect(result.groups.length).toBeGreaterThan(1);
+    expect(result.diagnostics.complexitySpreadByGroup.every((spread) => spread <= 1)).toBe(true);
+  });
+
+  test("flags prerequisite cycles and still produces total ordering", () => {
+    const result = groupChildrenDeterministically({
+      maxChildrenPerParent: 2,
+      targetComplexity: 3,
+      complexityBandWidth: 2,
+      nodes: [
+        { id: "x", statement: "Depends on y.", prerequisiteIds: ["y"] },
+        { id: "y", statement: "Depends on x.", prerequisiteIds: ["x"] },
+      ],
+    });
+
+    expect(result.diagnostics.warnings.map((warning) => warning.code)).toContain("cycle_detected");
+    expect(result.diagnostics.orderedNodeIds).toEqual(["x", "y"]);
+  });
+});

--- a/tests/tree-builder.test.ts
+++ b/tests/tree-builder.test.ts
@@ -25,6 +25,8 @@ describe("tree builder", () => {
     expect(tree.rootId).toMatch(/^p_/);
     expect(tree.leafIds).toEqual(["l1", "l2", "l3", "l4", "l5"]);
     expect(tree.maxDepth).toBeGreaterThan(0);
+    expect(tree.groupingDiagnostics.length).toBeGreaterThan(0);
+    expect(tree.groupingDiagnostics.every((layer) => layer.complexitySpreadByGroup.every((spread) => spread <= 2))).toBe(true);
 
     const validation = validateExplanationTree(tree, config.maxChildrenPerParent);
     expect(validation.ok).toBe(true);
@@ -45,6 +47,7 @@ describe("tree builder", () => {
     expect(tree.rootId).toBe("l1");
     expect(tree.maxDepth).toBe(0);
     expect(tree.groupPlan).toHaveLength(0);
+    expect(tree.groupingDiagnostics).toHaveLength(0);
 
     const validation = validateExplanationTree(tree, config.maxChildrenPerParent);
     expect(validation.ok).toBe(true);
@@ -82,6 +85,7 @@ describe("tree builder", () => {
       leafIds: ["l1", "l2"],
       configHash: "hash",
       groupPlan: [],
+      groupingDiagnostics: [],
       maxDepth: 1,
       nodes: {
         p1: {


### PR DESCRIPTION
## Summary
Implements issue #7 with a deterministic inductive child-grouping algorithm and integrates it into recursive tree construction.

## What was implemented
- Added `src/child-grouping.ts`:
  - `groupChildrenDeterministically(request)` with deterministic output
  - prerequisite-aware topological ordering (`prerequisiteIds`)
  - hard branching-factor cap (`maxChildrenPerParent`)
  - complexity-spread cap (`complexityBandWidth`) for sibling groups
  - deterministic semantic tie-breaking for candidate selection
  - machine-checkable diagnostics (`orderedNodeIds`, per-group complexity spread, warnings)
- Integrated grouping into `src/tree-builder.ts`:
  - replaced fixed chunk partitioning with grouping planner
  - added `groupingDiagnostics` on tree output
  - added `complexitySpread` in `groupPlan`
  - preserved deterministic parent-id derivation and full validation checks
- Updated exports in `src/index.ts`.
- Added tests in `tests/child-grouping.test.ts` for:
  - determinism under reordered input
  - prerequisite ordering
  - max-children + complexity-band enforcement
  - cycle fallback with warning
- Updated tree tests in `tests/tree-builder.test.ts` to assert grouping diagnostics are emitted and bounded.
- Added docs `docs/child-grouping.md` and updated `docs/tree-builder.md` + `README.md`.

## Validation
- `npm test`
- `npm run build`

Both pass locally.

## What remains
- #3/#4/#5: Lean declaration ingestion, dependency graph, and provenance leaf schema wiring into this grouping input.
- #6: Verity-specific domain adapter for prerequisite and semantic metadata.
- #25: richer pedagogy policy engine (term-introduction budgeting and prerequisite sequencing policy beyond grouping).
- #17: browser-triggered verification flow using leaf provenance links.

## Why this advances correctness/usability
This removes naive fixed chunking and introduces a deterministic, auditable grouping stage that explicitly tracks prerequisite order and complexity spread before parent synthesis, improving faithfulness and pedagogy control in the explanation-tree pipeline.

Closes #7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the explanation tree construction behavior by replacing fixed chunking with a new prerequisite/complexity-aware grouping planner, which will alter tree shapes and summary inputs. Risk is mitigated by deterministic rules plus added diagnostics and tests, but it touches core build logic.
> 
> **Overview**
> Adds a new deterministic `groupChildrenDeterministically` planner that topologically schedules children by `prerequisiteIds`, enforces `maxChildrenPerParent` and `complexityBandWidth`, and emits machine-checkable warnings/diagnostics.
> 
> Integrates this planner into `buildRecursiveExplanationTree`, replacing fixed chunk partitioning; tree outputs now include per-depth `groupingDiagnostics` and `groupPlan` entries record per-group `complexitySpread`. Updates exports, tests, and docs/README to cover the new grouping slice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d15f3b61599221ffc1110ba179de55b02f3140a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->