### PR TITLE
feat: issue #17 verification HTTP API for browser-triggered jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Inductive explanation trees from Lean specifications (Verity -> Yul case study).
 - Issue #25 follow-up: prerequisite-order policy now evaluates deterministic grouping order (not lexical IDs) and waives cyclic in-group edges, fixing real Verity SCC compatibility.
 - Issue #25 follow-up: tree builder now reorders each group by local prerequisites and uses a safe depth guard with explicit no-progress failure diagnostics for large Lean corpora.
 - Issue #17: browser-triggered verification workflow core with deterministic queue/status lifecycle, reproducibility contracts, and canonical ledger persistence.
+- Issue #17 follow-up: browser-callable verification HTTP API with deterministic route payloads, persisted ledger-backed job querying, and command-runner integration.
 
 ## Local checks
 ```bash
@@ -26,6 +27,7 @@ npm run bench:dependency-graph
 npm run ingest:lean -- /path/to/lean-project
 npm run eval:domain-adapters
 npm run eval:tree-pipeline -- /path/to/lean-project --include=Verity --include=Compiler/ContractSpec.lean
+npm run serve:verification
 ```
 
 ## Live provider check
@@ -46,3 +48,4 @@ EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live:summary
 - [Recursive tree builder](docs/tree-builder.md)
 - [Pedagogical policy engine](docs/pedagogical-policy.md)
 - [Browser-triggered verification flow](docs/verification-flow.md)
+- [Verification HTTP API service](docs/verification-api.md)

--- a/docs/verification-api.md
+++ b/docs/verification-api.md
@@ -1,0 +1,44 @@
+# Verification API Service
+
+Issue: #17
+
+## Scope
+- Provide browser-callable HTTP endpoints over `VerificationWorkflow`.
+- Persist every state transition to a canonical verification ledger.
+- Expose deterministic job hashes for provenance/audit UI.
+
+## Startup
+- `startVerificationHttpServer({ ledgerPath, host, port, runner, ...workflowOptions })`
+- On startup, server loads `ledgerPath` (if present) and resumes queue sequence deterministically.
+- `runner` defaults to `createChildProcessVerificationRunner()`.
+
+## Routes
+- `GET /health`
+  - Returns `{ ok: true, data: { status: "ok" } }`
+- `POST /api/verification/jobs`
+  - Enqueue one job from `{ target, reproducibility, options? }`
+  - Persists ledger immediately
+- `GET /api/verification/jobs`
+  - List all jobs
+  - Optional query `?leafId=<leaf-id>` filters by leaf
+- `GET /api/verification/jobs/:jobId`
+  - Fetch one job and deterministic `jobHash`
+- `POST /api/verification/jobs/:jobId/run`
+  - Execute a queued job immediately
+  - Conflict errors are returned as status `409`
+- `POST /api/verification/run-next`
+  - Executes the next queued job (or returns `job: null`)
+
+## Determinism and provenance
+- All successful responses include canonical workflow job records.
+- Job hashes are computed via `computeVerificationJobHash(job)`.
+- Ledger persistence uses `writeVerificationLedger(...)` after enqueue/run transitions.
+- Invalid enqueue payloads are explicit `400 invalid_request` responses.
+
+## Local operation
+- CLI: `npm run serve:verification`
+- Environment knobs:
+  - `EXPLAIN_MD_VERIFICATION_HOST` (default `127.0.0.1`)
+  - `EXPLAIN_MD_VERIFICATION_PORT` (default `8787`)
+  - `EXPLAIN_MD_VERIFICATION_LEDGER` (default `.explain-md/verification-ledger.json`)
+  - `EXPLAIN_MD_VERIFICATION_TIMEOUT_MS` (optional positive integer)

--- a/docs/verification-flow.md
+++ b/docs/verification-flow.md
@@ -43,6 +43,8 @@ Issue: #17
 - `buildLeanVerificationContract(...)` produces a reproducibility contract for `lake env lean <file>` checks.
 - `createVerificationTargetFromLeaf(leaf)` maps theorem leaves to verification targets.
 
-## Current boundary
-- This slice implements the full deterministic job/state/persistence core.
-- HTTP endpoint wiring and browser UI trigger integration remain separate adapters on top of this workflow.
+## API integration
+- HTTP endpoint adapter is provided in `verification-api.ts`:
+  - `startVerificationHttpServer(...)`
+  - `createChildProcessVerificationRunner(...)`
+- Endpoint contract is documented in `docs/verification-api.md`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "bench:dependency-graph": "npm run -s build && node scripts/benchmark-dependency-graph.mjs",
     "ingest:lean": "npm run -s build && node scripts/lean-ingest.mjs",
     "eval:domain-adapters": "npm run -s build && node scripts/eval-domain-adapters.mjs",
-    "eval:tree-pipeline": "npm run -s build && node scripts/eval-tree-pipeline.mjs"
+    "eval:tree-pipeline": "npm run -s build && node scripts/eval-tree-pipeline.mjs",
+    "serve:verification": "npm run -s build && node scripts/verification-server.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.4.0",

--- a/scripts/verification-server.mjs
+++ b/scripts/verification-server.mjs
@@ -1,0 +1,47 @@
+import path from "node:path";
+import process from "node:process";
+import { createChildProcessVerificationRunner, startVerificationHttpServer } from "../dist/index.js";
+
+const host = process.env.EXPLAIN_MD_VERIFICATION_HOST ?? "127.0.0.1";
+const portRaw = process.env.EXPLAIN_MD_VERIFICATION_PORT ?? "8787";
+const port = Number(portRaw);
+if (!Number.isInteger(port) || port < 0 || port > 65535) {
+  console.error(`Invalid EXPLAIN_MD_VERIFICATION_PORT: '${portRaw}'`);
+  process.exit(1);
+}
+
+const ledgerPath = path.resolve(process.env.EXPLAIN_MD_VERIFICATION_LEDGER ?? ".explain-md/verification-ledger.json");
+const defaultTimeoutRaw = process.env.EXPLAIN_MD_VERIFICATION_TIMEOUT_MS;
+const defaultTimeoutMs = defaultTimeoutRaw ? Number(defaultTimeoutRaw) : undefined;
+if (
+  defaultTimeoutRaw &&
+  (!Number.isInteger(defaultTimeoutMs) || (defaultTimeoutMs ?? 0) <= 0)
+) {
+  console.error(`Invalid EXPLAIN_MD_VERIFICATION_TIMEOUT_MS: '${defaultTimeoutRaw}'`);
+  process.exit(1);
+}
+
+const server = await startVerificationHttpServer({
+  host,
+  port,
+  ledgerPath,
+  defaultTimeoutMs,
+  runner: createChildProcessVerificationRunner(),
+});
+
+console.log(`verification_api_url=${server.url}`);
+console.log(`verification_ledger_path=${server.ledgerPath}`);
+
+const shutdown = async () => {
+  await server.close();
+};
+
+process.on("SIGINT", async () => {
+  await shutdown();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await shutdown();
+  process.exit(0);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export * from "./openai-provider.js";
 export * from "./summary-pipeline.js";
 export * from "./tree-builder.js";
 export * from "./verification-flow.js";
+export * from "./verification-api.js";
 export * from "./pedagogical-policy.js";

--- a/src/verification-api.ts
+++ b/src/verification-api.ts
@@ -1,0 +1,469 @@
+import { spawn } from "node:child_process";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  VerificationWorkflow,
+  computeVerificationJobHash,
+  readVerificationLedger,
+  writeVerificationLedger,
+  type VerificationCommandRunner,
+  type VerificationQueueEntry,
+  type VerificationQueueOptions,
+  type VerificationReproducibilityContract,
+  type VerificationRunOutput,
+  type VerificationTarget,
+  type VerificationWorkflowOptions,
+} from "./verification-flow.js";
+
+export interface ChildProcessRunnerOptions {
+  additionalEnv?: Record<string, string>;
+}
+
+export interface VerificationHttpServerOptions extends Omit<VerificationWorkflowOptions, "runner"> {
+  runner?: VerificationCommandRunner;
+  ledgerPath: string;
+  host?: string;
+  port?: number;
+}
+
+export interface VerificationHttpServer {
+  readonly url: string;
+  readonly ledgerPath: string;
+  close(): Promise<void>;
+}
+
+interface JsonResponse<T> {
+  ok: true;
+  data: T;
+}
+
+interface ErrorResponse {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export function createChildProcessVerificationRunner(options?: ChildProcessRunnerOptions): VerificationCommandRunner {
+  const additionalEnv = canonicalizeEnv(options?.additionalEnv ?? {});
+  return {
+    async run(contract: VerificationReproducibilityContract, timeoutMs: number): Promise<VerificationRunOutput> {
+      return runVerificationCommand(contract, timeoutMs, additionalEnv);
+    },
+  };
+}
+
+export async function startVerificationHttpServer(options: VerificationHttpServerOptions): Promise<VerificationHttpServer> {
+  const host = normalizeOptional(options.host) ?? "127.0.0.1";
+  const port = normalizePort(options.port ?? 8787);
+  const ledgerPath = path.resolve(options.ledgerPath);
+  const runner = options.runner ?? createChildProcessVerificationRunner();
+  const initialLedger = await readVerificationLedgerIfExists(ledgerPath);
+  const workflow = new VerificationWorkflow(
+    {
+      runner,
+      now: options.now,
+      idFactory: options.idFactory,
+      defaultTimeoutMs: options.defaultTimeoutMs,
+      maxLogLinesPerJob: options.maxLogLinesPerJob,
+    },
+    initialLedger,
+  );
+
+  const server = createServer(async (request, response) => {
+    try {
+      await handleRequest(request, response, workflow, ledgerPath);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeJson(response, 500, {
+        ok: false,
+        error: {
+          code: "internal_error",
+          message,
+        },
+      } satisfies ErrorResponse);
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to determine verification API server address.");
+  }
+
+  const url = `http://${address.address}:${address.port}`;
+  return {
+    url,
+    ledgerPath,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function handleRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  workflow: VerificationWorkflow,
+  ledgerPath: string,
+): Promise<void> {
+  const method = normalizeOptional(request.method) ?? "GET";
+  const url = new URL(request.url ?? "/", "http://localhost");
+  const pathname = url.pathname;
+
+  if (method === "GET" && pathname === "/health") {
+    writeJson(response, 200, { ok: true, data: { status: "ok" } } satisfies JsonResponse<{ status: string }>);
+    return;
+  }
+
+  if (method === "GET" && pathname === "/api/verification/jobs") {
+    const leafId = normalizeOptional(url.searchParams.get("leafId") ?? undefined);
+    const jobs = leafId ? workflow.listJobsForLeaf(leafId) : workflow.listJobs();
+    writeJson(response, 200, { ok: true, data: buildJobsPayload(jobs) } satisfies JsonResponse<ReturnType<typeof buildJobsPayload>>);
+    return;
+  }
+
+  if (method === "POST" && pathname === "/api/verification/jobs") {
+    try {
+      const payload = await readJsonBody<Partial<VerificationQueueEntry>>(request);
+      const entry = canonicalizeQueueEntry(payload);
+      const job = workflow.enqueue(entry);
+      await persistLedger(ledgerPath, workflow);
+      writeJson(response, 201, {
+        ok: true,
+        data: {
+          job,
+          jobHash: computeVerificationJobHash(job),
+        },
+      } satisfies JsonResponse<{ job: ReturnType<VerificationWorkflow["enqueue"]>; jobHash: string }>);
+    } catch (error: unknown) {
+      writeJson(response, 400, buildError("invalid_request", error));
+    }
+    return;
+  }
+
+  const jobRunMatch = matchPath(pathname, /^\/api\/verification\/jobs\/([^/]+)\/run$/);
+  if (method === "POST" && jobRunMatch) {
+    const jobId = decodeURIComponent(jobRunMatch[1]);
+    try {
+      const job = await workflow.runJob(jobId);
+      await persistLedger(ledgerPath, workflow);
+      writeJson(response, 200, {
+        ok: true,
+        data: {
+          job,
+          jobHash: computeVerificationJobHash(job),
+        },
+      } satisfies JsonResponse<{ job: Awaited<ReturnType<VerificationWorkflow["runJob"]>>; jobHash: string }>);
+    } catch (error: unknown) {
+      writeJson(response, 409, buildError("job_run_conflict", error));
+    }
+    return;
+  }
+
+  const jobGetMatch = matchPath(pathname, /^\/api\/verification\/jobs\/([^/]+)$/);
+  if (method === "GET" && jobGetMatch) {
+    const jobId = decodeURIComponent(jobGetMatch[1]);
+    const job = workflow.getJob(jobId);
+    if (!job) {
+      writeJson(response, 404, {
+        ok: false,
+        error: {
+          code: "job_not_found",
+          message: `Verification job '${jobId}' was not found.`,
+        },
+      } satisfies ErrorResponse);
+      return;
+    }
+    writeJson(response, 200, {
+      ok: true,
+      data: {
+        job,
+        jobHash: computeVerificationJobHash(job),
+      },
+    } satisfies JsonResponse<{ job: ReturnType<VerificationWorkflow["getJob"]>; jobHash: string }>);
+    return;
+  }
+
+  if (method === "POST" && pathname === "/api/verification/run-next") {
+    const job = await workflow.runNextQueuedJob();
+    if (job) {
+      await persistLedger(ledgerPath, workflow);
+    }
+    writeJson(response, 200, {
+      ok: true,
+      data: {
+        job,
+        jobHash: job ? computeVerificationJobHash(job) : undefined,
+      },
+    } satisfies JsonResponse<{ job: Awaited<ReturnType<VerificationWorkflow["runNextQueuedJob"]>>; jobHash?: string }>);
+    return;
+  }
+
+  writeJson(response, 404, {
+    ok: false,
+    error: {
+      code: "not_found",
+      message: `Route ${method} ${pathname} does not exist.`,
+    },
+  } satisfies ErrorResponse);
+}
+
+function buildJobsPayload(jobs: ReturnType<VerificationWorkflow["listJobs"]>): {
+  jobs: ReturnType<VerificationWorkflow["listJobs"]>;
+  jobHashes: Array<{ jobId: string; hash: string }>;
+} {
+  return {
+    jobs,
+    jobHashes: jobs.map((job) => ({
+      jobId: job.jobId,
+      hash: computeVerificationJobHash(job),
+    })),
+  };
+}
+
+function matchPath(pathname: string, pattern: RegExp): RegExpMatchArray | null {
+  const matched = pathname.match(pattern);
+  return matched ?? null;
+}
+
+function writeJson(response: ServerResponse, statusCode: number, payload: JsonResponse<unknown> | ErrorResponse): void {
+  const content = `${JSON.stringify(payload)}\n`;
+  response.statusCode = statusCode;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.setHeader("content-length", Buffer.byteLength(content));
+  response.end(content);
+}
+
+function buildError(code: string, error: unknown): ErrorResponse {
+  return {
+    ok: false,
+    error: {
+      code,
+      message: error instanceof Error ? error.message : String(error),
+    },
+  };
+}
+
+async function readJsonBody<T>(request: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) {
+    throw new Error("Request body is required.");
+  }
+
+  const raw = Buffer.concat(chunks).toString("utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Request body must be valid JSON.");
+  }
+  return parsed as T;
+}
+
+function canonicalizeQueueEntry(entry: Partial<VerificationQueueEntry>): VerificationQueueEntry {
+  if (!entry || typeof entry !== "object") {
+    throw new Error("Queue payload must be an object.");
+  }
+
+  return {
+    target: canonicalizeTarget(entry.target),
+    reproducibility: canonicalizeContract(entry.reproducibility),
+    options: canonicalizeOptions(entry.options),
+  };
+}
+
+function canonicalizeTarget(target: Partial<VerificationTarget> | undefined): VerificationTarget {
+  if (!target || typeof target !== "object") {
+    throw new Error("target is required.");
+  }
+
+  if (!target.sourceSpan || typeof target.sourceSpan !== "object") {
+    throw new Error("target.sourceSpan is required.");
+  }
+
+  return {
+    leafId: normalizeRequired(target.leafId, "target.leafId"),
+    declarationId: normalizeRequired(target.declarationId, "target.declarationId"),
+    modulePath: normalizeRequired(target.modulePath, "target.modulePath"),
+    declarationName: normalizeRequired(target.declarationName, "target.declarationName"),
+    sourceSpan: {
+      filePath: normalizeRequired(target.sourceSpan.filePath, "target.sourceSpan.filePath"),
+      startLine: normalizePositiveInt(target.sourceSpan.startLine, "target.sourceSpan.startLine"),
+      startColumn: normalizePositiveInt(target.sourceSpan.startColumn, "target.sourceSpan.startColumn"),
+      endLine: normalizePositiveInt(target.sourceSpan.endLine, "target.sourceSpan.endLine"),
+      endColumn: normalizePositiveInt(target.sourceSpan.endColumn, "target.sourceSpan.endColumn"),
+    },
+    sourceUrl: normalizeOptional(target.sourceUrl),
+  };
+}
+
+function canonicalizeContract(contract: Partial<VerificationReproducibilityContract> | undefined): VerificationReproducibilityContract {
+  if (!contract || typeof contract !== "object") {
+    throw new Error("reproducibility is required.");
+  }
+
+  if (!Array.isArray(contract.args)) {
+    throw new Error("reproducibility.args must be an array.");
+  }
+
+  return {
+    sourceRevision: normalizeRequired(contract.sourceRevision, "reproducibility.sourceRevision"),
+    workingDirectory: path.resolve(normalizeRequired(contract.workingDirectory, "reproducibility.workingDirectory")),
+    command: normalizeRequired(contract.command, "reproducibility.command"),
+    args: contract.args.map((arg, index) => normalizeRequired(arg, `reproducibility.args[${index}]`)),
+    env: canonicalizeEnv(contract.env ?? {}),
+    toolchain: {
+      leanVersion: normalizeRequired(contract.toolchain?.leanVersion, "reproducibility.toolchain.leanVersion"),
+      lakeVersion: normalizeOptional(contract.toolchain?.lakeVersion),
+    },
+  };
+}
+
+function canonicalizeOptions(options: Partial<VerificationQueueOptions> | undefined): VerificationQueueOptions | undefined {
+  if (!options || typeof options !== "object") {
+    return undefined;
+  }
+
+  if (options.timeoutMs === undefined) {
+    return undefined;
+  }
+
+  return {
+    timeoutMs: normalizePositiveInt(options.timeoutMs, "options.timeoutMs"),
+  };
+}
+
+function canonicalizeEnv(env: Record<string, string>): Record<string, string> {
+  const entries = Object.entries(env)
+    .map(([key, value]) => [normalizeRequired(key, "env key"), normalizeRequired(value, `env.${key}`)] as const)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return Object.fromEntries(entries);
+}
+
+function normalizeRequired(value: unknown, field: string): string {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${field} is required.`);
+  }
+  return normalized;
+}
+
+function normalizeOptional(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizePositiveInt(value: unknown, field: string): number {
+  const normalized = Number(value);
+  if (!Number.isInteger(normalized) || normalized <= 0) {
+    throw new Error(`${field} must be a positive integer.`);
+  }
+  return normalized;
+}
+
+function normalizePort(value: number): number {
+  const normalized = Number(value);
+  if (!Number.isInteger(normalized) || normalized < 0 || normalized > 65535) {
+    throw new Error("port must be an integer in [0, 65535].");
+  }
+  return normalized;
+}
+
+async function readVerificationLedgerIfExists(ledgerPath: string) {
+  try {
+    await fs.access(ledgerPath);
+  } catch {
+    return undefined;
+  }
+  return readVerificationLedger(ledgerPath);
+}
+
+async function persistLedger(ledgerPath: string, workflow: VerificationWorkflow): Promise<void> {
+  await writeVerificationLedger(ledgerPath, workflow.toLedger());
+}
+
+async function runVerificationCommand(
+  contract: VerificationReproducibilityContract,
+  timeoutMs: number,
+  additionalEnv: Record<string, string>,
+): Promise<VerificationRunOutput> {
+  return new Promise<VerificationRunOutput>((resolve, reject) => {
+    const startedAt = Date.now();
+    const child = spawn(contract.command, contract.args, {
+      cwd: contract.workingDirectory,
+      env: {
+        ...process.env,
+        ...additionalEnv,
+        ...contract.env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let timedOut = false;
+    let settled = false;
+
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdoutChunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderrChunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    });
+
+    child.once("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutHandle);
+      reject(error);
+    });
+
+    child.once("close", (code, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutHandle);
+      resolve({
+        exitCode: code,
+        signal,
+        durationMs: Date.now() - startedAt,
+        timedOut,
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: Buffer.concat(stderrChunks).toString("utf8"),
+      });
+    });
+  });
+}

--- a/tests/verification-api.test.ts
+++ b/tests/verification-api.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  buildLeanVerificationContract,
+  createVerificationTargetFromLeaf,
+  type VerificationCommandRunner,
+  type VerificationReproducibilityContract,
+  type VerificationRunOutput,
+} from "../src/verification-flow.js";
+import { startVerificationHttpServer } from "../src/verification-api.js";
+
+class FakeRunner implements VerificationCommandRunner {
+  private readonly outputs: VerificationRunOutput[];
+
+  public constructor(outputs: VerificationRunOutput[]) {
+    this.outputs = outputs;
+  }
+
+  public async run(_contract: VerificationReproducibilityContract, _timeoutMs: number): Promise<VerificationRunOutput> {
+    if (this.outputs.length === 0) {
+      throw new Error("No fake outputs left.");
+    }
+    return this.outputs.shift() as VerificationRunOutput;
+  }
+}
+
+const BASE_LEAF = {
+  schemaVersion: "1.0.0",
+  id: "leaf-main",
+  declarationId: "decl-main",
+  modulePath: "Verity/Core",
+  declarationName: "main",
+  theoremKind: "theorem" as const,
+  statementText: "Main theorem",
+  prettyStatement: "Main theorem",
+  sourceSpan: {
+    filePath: "Verity/Core.lean",
+    startLine: 10,
+    startColumn: 1,
+    endLine: 18,
+    endColumn: 8,
+  },
+  tags: ["verity:state"],
+  dependencyIds: ["decl-helper"],
+  sourceUrl: "https://example.com/Verity/Core.lean#L10C1-L18C8",
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.map(async (directory) => {
+      await rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("verification api", () => {
+  test("enqueue/run/list/get endpoints persist and reload deterministic ledger", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "explain-md-verification-api-"));
+    tempDirs.push(tempDir);
+    const ledgerPath = path.join(tempDir, "ledger.json");
+
+    const reproducibility = buildLeanVerificationContract({
+      projectRoot: "/tmp/project",
+      sourceRevision: "rev-a",
+      filePath: "Verity/Core.lean",
+      leanVersion: "4.13.0",
+      lakeVersion: "5.0.0",
+      env: { LEAN_PATH: "/tmp/project/.lake/packages" },
+    });
+    const target = createVerificationTargetFromLeaf(BASE_LEAF);
+
+    const firstServer = await startVerificationHttpServer({
+      ledgerPath,
+      runner: new FakeRunner([
+        {
+          exitCode: 0,
+          signal: null,
+          durationMs: 42,
+          timedOut: false,
+          stdout: "proof ok",
+          stderr: "",
+        },
+      ]),
+      idFactory: () => "job-0001",
+      now: () => new Date("2026-02-27T00:10:00.000Z"),
+      port: 0,
+    });
+
+    const createResponse = await fetch(`${firstServer.url}/api/verification/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ target, reproducibility }),
+    });
+    expect(createResponse.status).toBe(201);
+    const createdPayload = await createResponse.json();
+    expect(createdPayload.ok).toBe(true);
+    expect(createdPayload.data.job.status).toBe("queued");
+    expect(createdPayload.data.jobHash).toMatch(/^[0-9a-f]{64}$/);
+
+    const listQueuedResponse = await fetch(`${firstServer.url}/api/verification/jobs?leafId=leaf-main`);
+    expect(listQueuedResponse.status).toBe(200);
+    const listQueuedPayload = await listQueuedResponse.json();
+    expect(listQueuedPayload.data.jobs).toHaveLength(1);
+    expect(listQueuedPayload.data.jobs[0].status).toBe("queued");
+
+    const runResponse = await fetch(`${firstServer.url}/api/verification/jobs/job-0001/run`, { method: "POST" });
+    expect(runResponse.status).toBe(200);
+    const runPayload = await runResponse.json();
+    expect(runPayload.ok).toBe(true);
+    expect(runPayload.data.job.status).toBe("success");
+    expect(runPayload.data.job.result.exitCode).toBe(0);
+    expect(runPayload.data.job.logs[0].message).toBe("proof ok");
+
+    const getResponse = await fetch(`${firstServer.url}/api/verification/jobs/job-0001`);
+    expect(getResponse.status).toBe(200);
+    const getPayload = await getResponse.json();
+    expect(getPayload.data.job.status).toBe("success");
+    expect(getPayload.data.jobHash).toBe(runPayload.data.jobHash);
+
+    await firstServer.close();
+
+    const secondServer = await startVerificationHttpServer({
+      ledgerPath,
+      runner: new FakeRunner([]),
+      port: 0,
+    });
+
+    const listReloadedResponse = await fetch(`${secondServer.url}/api/verification/jobs`);
+    expect(listReloadedResponse.status).toBe(200);
+    const listReloadedPayload = await listReloadedResponse.json();
+    expect(listReloadedPayload.data.jobs).toHaveLength(1);
+    expect(listReloadedPayload.data.jobs[0].status).toBe("success");
+    expect(listReloadedPayload.data.jobHashes).toHaveLength(1);
+    expect(listReloadedPayload.data.jobHashes[0].jobId).toBe("job-0001");
+
+    const runNextResponse = await fetch(`${secondServer.url}/api/verification/run-next`, { method: "POST" });
+    expect(runNextResponse.status).toBe(200);
+    const runNextPayload = await runNextResponse.json();
+    expect(runNextPayload.data.job).toBeNull();
+
+    await secondServer.close();
+
+    const persistedLedger = JSON.parse(await readFile(ledgerPath, "utf8"));
+    expect(persistedLedger.schemaVersion).toBe("1.0.0");
+    expect(persistedLedger.jobs).toHaveLength(1);
+    expect(persistedLedger.jobs[0].jobId).toBe("job-0001");
+    expect(persistedLedger.jobs[0].status).toBe("success");
+  });
+
+  test("returns deterministic API errors for invalid payload and unknown routes", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "explain-md-verification-api-"));
+    tempDirs.push(tempDir);
+    const server = await startVerificationHttpServer({
+      ledgerPath: path.join(tempDir, "ledger.json"),
+      runner: new FakeRunner([]),
+      port: 0,
+    });
+
+    const invalidResponse = await fetch(`${server.url}/api/verification/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(invalidResponse.status).toBe(400);
+    const invalidPayload = await invalidResponse.json();
+    expect(invalidPayload.ok).toBe(false);
+    expect(invalidPayload.error.code).toBe("invalid_request");
+    expect(invalidPayload.error.message).toContain("target is required");
+
+    const unknownResponse = await fetch(`${server.url}/api/verification/unknown`);
+    expect(unknownResponse.status).toBe(404);
+    const unknownPayload = await unknownResponse.json();
+    expect(unknownPayload.ok).toBe(false);
+    expect(unknownPayload.error.code).toBe("not_found");
+
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Summary
Implements the missing browser-callable service layer for Issue #17 on top of the existing deterministic verification workflow core.

## What was implemented
- Added deterministic verification API server module:
  - `src/verification-api.ts`
  - `startVerificationHttpServer(...)`
  - `createChildProcessVerificationRunner(...)`
- Added HTTP routes for browser integration:
  - `GET /health`
  - `POST /api/verification/jobs`
  - `GET /api/verification/jobs`
  - `GET /api/verification/jobs/:jobId`
  - `POST /api/verification/jobs/:jobId/run`
  - `POST /api/verification/run-next`
- Added canonical hash surfacing (`jobHash`) for auditable UI/query responses.
- Added ledger-backed resume behavior (load-on-start, persist-on-enqueue/run transitions).
- Added server script:
  - `scripts/verification-server.mjs`
  - `npm run serve:verification`
- Added tests:
  - `tests/verification-api.test.ts`
  - Covers enqueue/list/run/get, reload-from-ledger, run-next when empty, invalid request and unknown routes.
- Updated exports/docs/readme:
  - `src/index.ts`
  - `docs/verification-api.md`
  - `docs/verification-flow.md`
  - `README.md`

## Determinism / provenance
- Canonical `VerificationWorkflow` records are returned directly from API routes.
- Every job response includes a deterministic SHA-256 job hash.
- Ledger persistence uses canonicalized workflow serialization.
- Invalid payloads return explicit machine-checkable API errors (`400 invalid_request`).

## Local validation
- `npm test` -> pass (`73/73`)
- `npm run build` -> pass
- `timeout 3 npm run serve:verification` -> starts server and prints deterministic URL/ledger path output

## What remains
1. Connect these endpoints to the frontend leaf panel and tree UI actions (`#15`, `#16`).
2. Add auth/multi-tenant policy around verification endpoints if needed for hosted deployments.
3. Add CI workflow job to run API integration tests in GitHub Actions once issue `#21` is implemented.

## How this advances objective
This removes the main integration gap between the provenance-preserving verification core and browser workflows: leaves can now trigger/query reproducible proof checks through deterministic, ledger-backed endpoints suitable for UI wiring.

Closes part of #17.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new HTTP server adapter and a child-process runner that executes verification commands, which increases exposure to input validation and command-execution edge cases. Risk is mitigated by strict request canonicalization, deterministic responses, and integration tests covering persistence and error paths.
> 
> **Overview**
> Implements a new verification HTTP API (`startVerificationHttpServer`) on top of the existing `VerificationWorkflow`, including endpoints to **enqueue jobs**, **list/filter jobs**, **fetch a job with deterministic `jobHash`**, and **run jobs** (by id or `run-next`) while persisting every state transition to the verification ledger.
> 
> Adds a `createChildProcessVerificationRunner` (and `npm run serve:verification` script) to run reproducibility contracts via spawned commands with timeout handling, exports the new module from `src/index.ts`, and updates docs/README plus new tests that validate ledger-backed resume and deterministic error responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e943ce2f5413dd2cd2544498c36467f8f1f36f2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->