### PR TITLE
feat: issue #16 deterministic leaf-detail provenance contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Inductive explanation trees from Lean specifications (Verity -> Yul case study).
 - Issue #25 follow-up: tree builder now reorders each group by local prerequisites and uses a safe depth guard with explicit no-progress failure diagnostics for large Lean corpora.
 - Issue #17: browser-triggered verification workflow core with deterministic queue/status lifecycle, reproducibility contracts, and canonical ledger persistence.
 - Issue #17 follow-up: browser-callable verification HTTP API with deterministic route payloads, persisted ledger-backed job querying, and command-runner integration.
+- Issue #16: deterministic leaf-detail/provenance contract for theorem inspection, source linking/share references, and verification-job binding for browser panels.
 
 ## Local checks
 ```bash
@@ -27,6 +28,7 @@ npm run bench:dependency-graph
 npm run ingest:lean -- /path/to/lean-project
 npm run eval:domain-adapters
 npm run eval:tree-pipeline -- /path/to/lean-project --include=Verity --include=Compiler/ContractSpec.lean
+npm run eval:leaf-detail -- /path/to/lean-project --include=Verity --leaf=<leaf-id>
 npm run serve:verification
 ```
 
@@ -49,3 +51,4 @@ EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live:summary
 - [Pedagogical policy engine](docs/pedagogical-policy.md)
 - [Browser-triggered verification flow](docs/verification-flow.md)
 - [Verification HTTP API service](docs/verification-api.md)
+- [Leaf detail contract](docs/leaf-detail.md)

--- a/docs/leaf-detail.md
+++ b/docs/leaf-detail.md
@@ -1,0 +1,49 @@
+# Leaf Detail Contract
+
+Issue: #16
+
+## Purpose
+`leaf-detail` builds a deterministic, provenance-first view model for a single theorem leaf so UI clients can render:
+- exact Lean theorem metadata,
+- root-to-leaf provenance path,
+- source-link/share references,
+- verification history anchored by canonical job hashes.
+
+This module is backend-only and intentionally UI-framework agnostic.
+
+## API
+
+### `buildLeafDetailView(tree, leaves, leafId, options)`
+Returns:
+- `ok`: `false` only when required data integrity fails (leaf missing/unreachable, missing tree node).
+- `diagnostics`: machine-checkable diagnostics with code/severity/details.
+- `view`: deterministic leaf-detail payload when available.
+
+`options`:
+- `verificationJobs`: optional persisted verification jobs used to bind job history to the target leaf.
+
+### `renderLeafDetailCanonical(view)`
+Canonical plain-text rendering with stable ordering for audits.
+
+### `computeLeafDetailHash(view)`
+`sha256(renderLeafDetailCanonical(view))`.
+
+## Determinism and provenance guarantees
+- Leaf lookup is canonicalized through theorem-leaf normalization.
+- Provenance path search is deterministic from `tree.rootId` following stable `childIds` order.
+- Verification jobs are filtered by `target.leafId` and sorted by `(queueSequence, jobId)`.
+- Every attached verification job includes canonical `jobHash` from verification flow.
+- Missing source URL is represented as an explicit warning diagnostic, not silent omission.
+
+## Diagnostics
+- `leaf_not_found` (`error`)
+- `leaf_not_reachable` (`error`)
+- `missing_node` (`error`)
+- `missing_source_url` (`warning`)
+
+## Reproducible evaluation command
+```bash
+npm run eval:leaf-detail -- tests/fixtures/lean-project --include=Verity --leaf=lean:Verity.Core:add_assoc:4:1
+```
+
+Output includes `detailOk`, `provenanceDepth`, diagnostics, and `leafDetailHash`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ingest:lean": "npm run -s build && node scripts/lean-ingest.mjs",
     "eval:domain-adapters": "npm run -s build && node scripts/eval-domain-adapters.mjs",
     "eval:tree-pipeline": "npm run -s build && node scripts/eval-tree-pipeline.mjs",
+    "eval:leaf-detail": "npm run -s build && node scripts/eval-leaf-detail.mjs",
     "serve:verification": "npm run -s build && node scripts/verification-server.mjs"
   },
   "devDependencies": {

--- a/scripts/eval-leaf-detail.mjs
+++ b/scripts/eval-leaf-detail.mjs
@@ -1,0 +1,134 @@
+import path from "node:path";
+import process from "node:process";
+import {
+  buildLeafDetailView,
+  buildRecursiveExplanationTree,
+  computeLeafDetailHash,
+  ingestLeanProject,
+  mapLeanIngestionToTheoremLeaves,
+  mapTheoremLeavesToTreeLeaves,
+  normalizeConfig,
+} from "../dist/index.js";
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const cwd = process.cwd();
+
+  let projectRoot = cwd;
+  let leafId;
+  const includePaths = [];
+
+  for (const arg of args) {
+    if (arg.startsWith("--leaf=")) {
+      leafId = arg.slice("--leaf=".length);
+      continue;
+    }
+    if (arg.startsWith("--include=")) {
+      includePaths.push(arg.slice("--include=".length));
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      projectRoot = path.resolve(cwd, arg);
+    }
+  }
+
+  return { projectRoot, includePaths, leafId };
+}
+
+function extractChildren(prompt) {
+  const lines = prompt.split("\n");
+  const children = [];
+  for (const line of lines) {
+    const match = line.match(/^- id=([^\s]+)(?:\s+complexity=\d+)?\s+statement=(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    try {
+      children.push({ id: match[1], statement: JSON.parse(match[2]) });
+    } catch {
+      children.push({ id: match[1], statement: match[2] });
+    }
+  }
+
+  children.sort((left, right) => left.id.localeCompare(right.id));
+  return children;
+}
+
+function deterministicSummaryProvider() {
+  return {
+    generate: async (request) => {
+      const children = extractChildren(request.messages?.[1]?.content ?? "");
+      const evidenceRefs = children.map((child) => child.id);
+      const statement = children.map((child) => `(${child.statement})`).join(" and ");
+
+      return {
+        text: JSON.stringify({
+          parent_statement: statement,
+          why_true_from_children: statement,
+          new_terms_introduced: [],
+          complexity_score: 3,
+          abstraction_score: 3,
+          evidence_refs: evidenceRefs,
+          confidence: 0.99,
+        }),
+        model: "mock-deterministic",
+        finishReason: "stop",
+        raw: {},
+      };
+    },
+    stream: async function* () {
+      return;
+    },
+  };
+}
+
+async function main() {
+  const { projectRoot, includePaths, leafId } = parseArgs(process.argv);
+  const ingestion = await ingestLeanProject(projectRoot, {
+    includePaths: includePaths.length > 0 ? includePaths : undefined,
+  });
+
+  const theoremLeaves = mapLeanIngestionToTheoremLeaves(ingestion);
+  const treeLeaves = mapTheoremLeavesToTreeLeaves(theoremLeaves);
+  if (treeLeaves.length === 0) {
+    throw new Error("No leaves found for evaluation.");
+  }
+
+  const config = normalizeConfig({
+    maxChildrenPerParent: 5,
+    complexityLevel: 3,
+    complexityBandWidth: 2,
+    termIntroductionBudget: 0,
+  });
+
+  const tree = await buildRecursiveExplanationTree(deterministicSummaryProvider(), {
+    leaves: treeLeaves,
+    config,
+  });
+
+  const targetLeafId = leafId ?? tree.leafIds[0];
+  const detail = buildLeafDetailView(tree, theoremLeaves, targetLeafId);
+
+  const result = {
+    projectRoot,
+    includePaths,
+    targetLeafId,
+    treeRootId: tree.rootId,
+    treeNodeCount: Object.keys(tree.nodes).length,
+    leafCount: theoremLeaves.length,
+    detailOk: detail.ok,
+    detailDiagnostics: detail.diagnostics,
+    provenanceDepth: detail.view?.provenancePath.length ?? 0,
+    hasSourceUrl: Boolean(detail.view?.leaf.sourceUrl),
+    verificationJobsBound: detail.view?.verification.summary.totalJobs ?? 0,
+    leafDetailHash: detail.view ? computeLeafDetailHash(detail.view) : undefined,
+  };
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`eval-leaf-detail failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from "./child-grouping.js";
 export * from "./openai-provider.js";
 export * from "./summary-pipeline.js";
 export * from "./tree-builder.js";
+export * from "./leaf-detail.js";
 export * from "./verification-flow.js";
 export * from "./verification-api.js";
 export * from "./pedagogical-policy.js";

--- a/src/leaf-detail.ts
+++ b/src/leaf-detail.ts
@@ -1,0 +1,347 @@
+import { createHash } from "node:crypto";
+import {
+  computeVerificationJobHash,
+  type VerificationJob,
+  type VerificationStatus,
+} from "./verification-flow.js";
+import {
+  canonicalizeTheoremLeafRecord,
+  renderTheoremLeafCanonical,
+  type TheoremLeafRecord,
+} from "./leaf-schema.js";
+import type { ExplanationTree, ExplanationTreeNode } from "./tree-builder.js";
+
+export type LeafDetailDiagnosticCode =
+  | "leaf_not_found"
+  | "leaf_not_reachable"
+  | "missing_node"
+  | "missing_source_url";
+
+export interface LeafDetailDiagnostic {
+  code: LeafDetailDiagnosticCode;
+  severity: "error" | "warning";
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface ProvenancePathNode {
+  id: string;
+  kind: ExplanationTreeNode["kind"];
+  depth: number;
+  statement: string;
+  evidenceRefs: string[];
+  childIds: string[];
+}
+
+export interface LeafShareReference {
+  compact: string;
+  markdown: string;
+  sourceUrl?: string;
+}
+
+export interface LeafVerificationJobSummary {
+  jobId: string;
+  queueSequence: number;
+  status: VerificationStatus;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  jobHash: string;
+  durationMs?: number;
+}
+
+export interface LeafVerificationSummary {
+  totalJobs: number;
+  latestStatus?: VerificationStatus;
+  latestJobId?: string;
+  statusCounts: Record<VerificationStatus, number>;
+}
+
+export interface LeafDetailView {
+  leaf: TheoremLeafRecord;
+  rootId: string;
+  provenancePath: ProvenancePathNode[];
+  shareReference: LeafShareReference;
+  verification: {
+    jobs: LeafVerificationJobSummary[];
+    summary: LeafVerificationSummary;
+  };
+  diagnostics: LeafDetailDiagnostic[];
+}
+
+export interface LeafDetailResult {
+  ok: boolean;
+  diagnostics: LeafDetailDiagnostic[];
+  view?: LeafDetailView;
+}
+
+export interface BuildLeafDetailOptions {
+  verificationJobs?: VerificationJob[];
+}
+
+export function buildLeafDetailView(
+  tree: ExplanationTree,
+  leaves: TheoremLeafRecord[],
+  leafId: string,
+  options: BuildLeafDetailOptions = {},
+): LeafDetailResult {
+  const diagnostics: LeafDetailDiagnostic[] = [];
+  const normalizedLeafId = normalizeRequired(leafId, "leafId");
+  const leafById = new Map<string, TheoremLeafRecord>();
+
+  for (const leaf of leaves) {
+    const canonical = canonicalizeTheoremLeafRecord(leaf);
+    if (!leafById.has(canonical.id)) {
+      leafById.set(canonical.id, canonical);
+    }
+  }
+
+  const leaf = leafById.get(normalizedLeafId);
+  if (!leaf) {
+    diagnostics.push({
+      code: "leaf_not_found",
+      severity: "error",
+      message: `Leaf '${normalizedLeafId}' was not found in provided theorem leaves.`,
+    });
+    return { ok: false, diagnostics };
+  }
+
+  const provenanceSearch = findProvenancePath(tree, normalizedLeafId);
+  diagnostics.push(...provenanceSearch.diagnostics);
+  if (!provenanceSearch.pathNodeIds) {
+    diagnostics.push({
+      code: "leaf_not_reachable",
+      severity: "error",
+      message: `Leaf '${normalizedLeafId}' is not reachable from root '${tree.rootId}'.`,
+      details: { rootId: tree.rootId, leafId: normalizedLeafId },
+    });
+    return { ok: false, diagnostics };
+  }
+
+  if (!leaf.sourceUrl) {
+    diagnostics.push({
+      code: "missing_source_url",
+      severity: "warning",
+      message: `Leaf '${normalizedLeafId}' has no sourceUrl; source deep-link is unavailable.`,
+      details: {
+        filePath: leaf.sourceSpan.filePath,
+        startLine: leaf.sourceSpan.startLine,
+        startColumn: leaf.sourceSpan.startColumn,
+      },
+    });
+  }
+
+  const verificationJobs = summarizeVerificationJobs(options.verificationJobs ?? [], normalizedLeafId);
+  const view: LeafDetailView = {
+    leaf,
+    rootId: tree.rootId,
+    provenancePath: provenanceSearch.pathNodeIds
+      .map((nodeId) => tree.nodes[nodeId])
+      .filter((node): node is ExplanationTreeNode => Boolean(node))
+      .map((node) => ({
+        id: node.id,
+        kind: node.kind,
+        depth: node.depth,
+        statement: node.statement,
+        evidenceRefs: node.evidenceRefs.slice(),
+        childIds: node.childIds.slice(),
+      })),
+    shareReference: buildShareReference(leaf),
+    verification: verificationJobs,
+    diagnostics: diagnostics.slice(),
+  };
+
+  return {
+    ok: !diagnostics.some((diagnostic) => diagnostic.severity === "error"),
+    diagnostics,
+    view,
+  };
+}
+
+export function renderLeafDetailCanonical(view: LeafDetailView): string {
+  const lines = [
+    "schema=leaf-detail-v1",
+    `root_id=${view.rootId}`,
+    `leaf_id=${view.leaf.id}`,
+    "leaf_canonical_start",
+    renderTheoremLeafCanonical(view.leaf),
+    "leaf_canonical_end",
+    `path_length=${view.provenancePath.length}`,
+    ...view.provenancePath.map((node, index) =>
+      [
+        `path[${index}].id=${node.id}`,
+        `path[${index}].kind=${node.kind}`,
+        `path[${index}].depth=${node.depth}`,
+        `path[${index}].statement=${JSON.stringify(node.statement)}`,
+        `path[${index}].evidence_refs=${node.evidenceRefs.join(",") || "none"}`,
+        `path[${index}].child_ids=${node.childIds.join(",") || "none"}`,
+      ].join("\n"),
+    ),
+    `share.compact=${view.shareReference.compact}`,
+    `share.markdown=${JSON.stringify(view.shareReference.markdown)}`,
+    `share.source_url=${view.shareReference.sourceUrl ?? "none"}`,
+    `verification.total_jobs=${view.verification.summary.totalJobs}`,
+    `verification.latest_status=${view.verification.summary.latestStatus ?? "none"}`,
+    `verification.latest_job_id=${view.verification.summary.latestJobId ?? "none"}`,
+    ...(["queued", "running", "success", "failure", "timeout"] as const).map(
+      (status) => `verification.count.${status}=${view.verification.summary.statusCounts[status]}`,
+    ),
+    ...view.verification.jobs.map((job, index) =>
+      [
+        `verification.jobs[${index}].job_id=${job.jobId}`,
+        `verification.jobs[${index}].queue_sequence=${job.queueSequence}`,
+        `verification.jobs[${index}].status=${job.status}`,
+        `verification.jobs[${index}].created_at=${job.createdAt}`,
+        `verification.jobs[${index}].started_at=${job.startedAt ?? "none"}`,
+        `verification.jobs[${index}].finished_at=${job.finishedAt ?? "none"}`,
+        `verification.jobs[${index}].duration_ms=${job.durationMs ?? "none"}`,
+        `verification.jobs[${index}].hash=${job.jobHash}`,
+      ].join("\n"),
+    ),
+    `diagnostics_count=${view.diagnostics.length}`,
+    ...view.diagnostics.map((diagnostic, index) =>
+      [
+        `diagnostics[${index}].code=${diagnostic.code}`,
+        `diagnostics[${index}].severity=${diagnostic.severity}`,
+        `diagnostics[${index}].message=${JSON.stringify(diagnostic.message)}`,
+        `diagnostics[${index}].details=${JSON.stringify(diagnostic.details ?? {})}`,
+      ].join("\n"),
+    ),
+  ];
+
+  return lines.join("\n");
+}
+
+export function computeLeafDetailHash(view: LeafDetailView): string {
+  return createHash("sha256").update(renderLeafDetailCanonical(view)).digest("hex");
+}
+
+function summarizeVerificationJobs(
+  jobs: VerificationJob[],
+  leafId: string,
+): {
+  jobs: LeafVerificationJobSummary[];
+  summary: LeafVerificationSummary;
+} {
+  const filtered = jobs
+    .filter((job) => job.target.leafId === leafId)
+    .slice()
+    .sort((left, right) => {
+      if (left.queueSequence !== right.queueSequence) {
+        return left.queueSequence - right.queueSequence;
+      }
+      return left.jobId.localeCompare(right.jobId);
+    });
+
+  const summaries = filtered.map((job) => ({
+    jobId: job.jobId,
+    queueSequence: job.queueSequence,
+    status: job.status,
+    createdAt: job.createdAt,
+    startedAt: job.startedAt,
+    finishedAt: job.finishedAt,
+    durationMs: job.result?.durationMs,
+    jobHash: computeVerificationJobHash(job),
+  }));
+
+  const statusCounts: Record<VerificationStatus, number> = {
+    queued: 0,
+    running: 0,
+    success: 0,
+    failure: 0,
+    timeout: 0,
+  };
+
+  for (const job of summaries) {
+    statusCounts[job.status] += 1;
+  }
+
+  const latest = summaries[summaries.length - 1];
+  return {
+    jobs: summaries,
+    summary: {
+      totalJobs: summaries.length,
+      latestStatus: latest?.status,
+      latestJobId: latest?.jobId,
+      statusCounts,
+    },
+  };
+}
+
+function buildShareReference(leaf: TheoremLeafRecord): LeafShareReference {
+  const span = `${leaf.sourceSpan.startLine}:${leaf.sourceSpan.startColumn}-${leaf.sourceSpan.endLine}:${leaf.sourceSpan.endColumn}`;
+  const declaration = `${leaf.modulePath}.${leaf.declarationName}`;
+  const compact = `${declaration}@${span}`;
+
+  return {
+    compact,
+    markdown: leaf.sourceUrl ? `[${declaration}](${leaf.sourceUrl})` : `\`${compact}\``,
+    sourceUrl: leaf.sourceUrl,
+  };
+}
+
+function findProvenancePath(
+  tree: ExplanationTree,
+  leafId: string,
+): { pathNodeIds: string[] | null; diagnostics: LeafDetailDiagnostic[] } {
+  const diagnostics: LeafDetailDiagnostic[] = [];
+  const root = tree.nodes[tree.rootId];
+  if (!root) {
+    diagnostics.push({
+      code: "missing_node",
+      severity: "error",
+      message: `Tree root '${tree.rootId}' is missing from nodes map.`,
+      details: { nodeId: tree.rootId },
+    });
+    return { pathNodeIds: null, diagnostics };
+  }
+
+  const queue: Array<{ nodeId: string; path: string[] }> = [{ nodeId: tree.rootId, path: [tree.rootId] }];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const current = queue.shift() as { nodeId: string; path: string[] };
+    if (current.nodeId === leafId) {
+      return { pathNodeIds: current.path, diagnostics };
+    }
+
+    if (visited.has(current.nodeId)) {
+      continue;
+    }
+    visited.add(current.nodeId);
+
+    const node = tree.nodes[current.nodeId];
+    if (!node) {
+      diagnostics.push({
+        code: "missing_node",
+        severity: "error",
+        message: `Node '${current.nodeId}' is missing from tree map.`,
+        details: { nodeId: current.nodeId },
+      });
+      continue;
+    }
+
+    for (const childId of node.childIds) {
+      if (!tree.nodes[childId]) {
+        diagnostics.push({
+          code: "missing_node",
+          severity: "error",
+          message: `Child node '${childId}' referenced by '${node.id}' is missing.`,
+          details: { nodeId: node.id, childId },
+        });
+        continue;
+      }
+      queue.push({ nodeId: childId, path: [...current.path, childId] });
+    }
+  }
+
+  return { pathNodeIds: null, diagnostics };
+}
+
+function normalizeRequired(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${field} is required.`);
+  }
+  return normalized;
+}

--- a/tests/leaf-detail.test.ts
+++ b/tests/leaf-detail.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "vitest";
+import type { TheoremLeafRecord } from "../src/leaf-schema.js";
+import {
+  buildLeafDetailView,
+  computeLeafDetailHash,
+  renderLeafDetailCanonical,
+  type LeafDetailView,
+} from "../src/leaf-detail.js";
+import type { ExplanationTree } from "../src/tree-builder.js";
+import type { VerificationJob } from "../src/verification-flow.js";
+
+describe("leaf detail", () => {
+  test("builds root-to-leaf provenance details with source share reference", () => {
+    const result = buildLeafDetailView(sampleTree(), sampleLeaves(), "leaf-a", {
+      verificationJobs: sampleVerificationJobs(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.view).toBeDefined();
+
+    const view = result.view as LeafDetailView;
+    expect(view.leaf.id).toBe("leaf-a");
+    expect(view.provenancePath.map((node) => node.id)).toEqual(["p-root", "p-mid", "leaf-a"]);
+    expect(view.shareReference.compact).toContain("Verity.Core.theoremA@");
+    expect(view.shareReference.markdown).toContain("https://github.com/example/verity");
+    expect(view.verification.summary.totalJobs).toBe(2);
+    expect(view.verification.summary.latestStatus).toBe("success");
+    expect(view.verification.jobs[0].jobHash).toHaveLength(64);
+  });
+
+  test("returns warning diagnostic when source URL is missing", () => {
+    const leaves = sampleLeaves();
+    leaves[0] = { ...leaves[0], sourceUrl: undefined };
+
+    const result = buildLeafDetailView(sampleTree(), leaves, "leaf-a");
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain("missing_source_url");
+    expect(result.diagnostics.map((diagnostic) => diagnostic.severity)).toContain("warning");
+  });
+
+  test("returns error for unknown leaf", () => {
+    const result = buildLeafDetailView(sampleTree(), sampleLeaves(), "missing-leaf");
+    expect(result.ok).toBe(false);
+    expect(result.view).toBeUndefined();
+    expect(result.diagnostics[0]?.code).toBe("leaf_not_found");
+  });
+
+  test("produces deterministic canonical rendering and hash", () => {
+    const first = buildLeafDetailView(sampleTree(), sampleLeaves(), "leaf-a", {
+      verificationJobs: sampleVerificationJobs(),
+    });
+    const second = buildLeafDetailView(sampleTree(), sampleLeaves(), "leaf-a", {
+      verificationJobs: sampleVerificationJobs().reverse(),
+    });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+
+    const firstView = first.view as LeafDetailView;
+    const secondView = second.view as LeafDetailView;
+    expect(renderLeafDetailCanonical(firstView)).toBe(renderLeafDetailCanonical(secondView));
+    expect(computeLeafDetailHash(firstView)).toBe(computeLeafDetailHash(secondView));
+  });
+});
+
+function sampleTree(): ExplanationTree {
+  return {
+    rootId: "p-root",
+    leafIds: ["leaf-a", "leaf-b"],
+    configHash: "cfg",
+    groupPlan: [],
+    groupingDiagnostics: [],
+    policyDiagnosticsByParent: {},
+    maxDepth: 2,
+    nodes: {
+      "p-root": {
+        id: "p-root",
+        kind: "parent",
+        statement: "Root statement",
+        childIds: ["p-mid", "leaf-b"],
+        depth: 2,
+        evidenceRefs: ["p-mid", "leaf-b"],
+      },
+      "p-mid": {
+        id: "p-mid",
+        kind: "parent",
+        statement: "Intermediate statement",
+        childIds: ["leaf-a"],
+        depth: 1,
+        evidenceRefs: ["leaf-a"],
+      },
+      "leaf-a": {
+        id: "leaf-a",
+        kind: "leaf",
+        statement: "Leaf A",
+        childIds: [],
+        depth: 0,
+        evidenceRefs: ["leaf-a"],
+      },
+      "leaf-b": {
+        id: "leaf-b",
+        kind: "leaf",
+        statement: "Leaf B",
+        childIds: [],
+        depth: 0,
+        evidenceRefs: ["leaf-b"],
+      },
+    },
+  };
+}
+
+function sampleLeaves(): TheoremLeafRecord[] {
+  return [
+    {
+      schemaVersion: "1.0.0",
+      id: "leaf-a",
+      declarationId: "leaf-a",
+      modulePath: "Verity.Core",
+      declarationName: "theoremA",
+      theoremKind: "theorem",
+      statementText: "theoremA statement",
+      prettyStatement: "theoremA statement",
+      sourceSpan: {
+        filePath: "Verity/Core.lean",
+        startLine: 10,
+        startColumn: 1,
+        endLine: 12,
+        endColumn: 10,
+      },
+      tags: ["verity"],
+      dependencyIds: [],
+      sourceUrl: "https://github.com/example/verity/blob/main/Verity/Core.lean#L10",
+    },
+    {
+      schemaVersion: "1.0.0",
+      id: "leaf-b",
+      declarationId: "leaf-b",
+      modulePath: "Verity.Core",
+      declarationName: "theoremB",
+      theoremKind: "theorem",
+      statementText: "theoremB statement",
+      prettyStatement: "theoremB statement",
+      sourceSpan: {
+        filePath: "Verity/Core.lean",
+        startLine: 20,
+        startColumn: 1,
+        endLine: 22,
+        endColumn: 10,
+      },
+      tags: [],
+      dependencyIds: ["leaf-a"],
+    },
+  ];
+}
+
+function sampleVerificationJobs(): VerificationJob[] {
+  return [
+    {
+      schemaVersion: "1.0.0",
+      jobId: "job-2",
+      queueSequence: 2,
+      status: "success",
+      target: {
+        leafId: "leaf-a",
+        declarationId: "leaf-a",
+        modulePath: "Verity.Core",
+        declarationName: "theoremA",
+        sourceSpan: {
+          filePath: "Verity/Core.lean",
+          startLine: 10,
+          startColumn: 1,
+          endLine: 12,
+          endColumn: 10,
+        },
+        sourceUrl: "https://github.com/example/verity/blob/main/Verity/Core.lean#L10",
+      },
+      reproducibility: {
+        sourceRevision: "abc123",
+        workingDirectory: "/tmp/verity",
+        command: "lake",
+        args: ["env", "lean", "Verity/Core.lean"],
+        env: {},
+        toolchain: {
+          leanVersion: "4.15.0",
+          lakeVersion: "5.0.0",
+        },
+      },
+      timeoutMs: 1000,
+      createdAt: "2026-02-26T10:00:00.000Z",
+      updatedAt: "2026-02-26T10:00:02.000Z",
+      startedAt: "2026-02-26T10:00:01.000Z",
+      finishedAt: "2026-02-26T10:00:02.000Z",
+      logs: [],
+      result: {
+        exitCode: 0,
+        signal: null,
+        durationMs: 123,
+        logsTruncated: false,
+        logLineCount: 0,
+      },
+    },
+    {
+      schemaVersion: "1.0.0",
+      jobId: "job-1",
+      queueSequence: 1,
+      status: "failure",
+      target: {
+        leafId: "leaf-a",
+        declarationId: "leaf-a",
+        modulePath: "Verity.Core",
+        declarationName: "theoremA",
+        sourceSpan: {
+          filePath: "Verity/Core.lean",
+          startLine: 10,
+          startColumn: 1,
+          endLine: 12,
+          endColumn: 10,
+        },
+      },
+      reproducibility: {
+        sourceRevision: "abc123",
+        workingDirectory: "/tmp/verity",
+        command: "lake",
+        args: ["env", "lean", "Verity/Core.lean"],
+        env: {},
+        toolchain: {
+          leanVersion: "4.15.0",
+        },
+      },
+      timeoutMs: 1000,
+      createdAt: "2026-02-26T09:00:00.000Z",
+      updatedAt: "2026-02-26T09:00:02.000Z",
+      startedAt: "2026-02-26T09:00:01.000Z",
+      finishedAt: "2026-02-26T09:00:02.000Z",
+      logs: [],
+      result: {
+        exitCode: 1,
+        signal: null,
+        durationMs: 122,
+        logsTruncated: false,
+        logLineCount: 0,
+      },
+    },
+    {
+      schemaVersion: "1.0.0",
+      jobId: "job-other",
+      queueSequence: 3,
+      status: "queued",
+      target: {
+        leafId: "leaf-b",
+        declarationId: "leaf-b",
+        modulePath: "Verity.Core",
+        declarationName: "theoremB",
+        sourceSpan: {
+          filePath: "Verity/Core.lean",
+          startLine: 20,
+          startColumn: 1,
+          endLine: 22,
+          endColumn: 10,
+        },
+      },
+      reproducibility: {
+        sourceRevision: "abc123",
+        workingDirectory: "/tmp/verity",
+        command: "lake",
+        args: ["env", "lean", "Verity/Core.lean"],
+        env: {},
+        toolchain: {
+          leanVersion: "4.15.0",
+        },
+      },
+      timeoutMs: 1000,
+      createdAt: "2026-02-26T11:00:00.000Z",
+      updatedAt: "2026-02-26T11:00:00.000Z",
+      logs: [],
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
Implements the next leverageful step for #16 by adding a deterministic backend contract for the leaf detail panel.

This unlocks browser/UI integration with a stable, auditable payload that combines:
- theorem metadata and source span,
- root-to-leaf provenance path from the explanation tree,
- shareable theorem reference strings,
- verification-job history bound to the leaf with canonical job hashes.

## What was implemented
- New module: `src/leaf-detail.ts`
  - `buildLeafDetailView(tree, leaves, leafId, options)`
  - `renderLeafDetailCanonical(view)`
  - `computeLeafDetailHash(view)`
- Deterministic diagnostics:
  - `leaf_not_found`, `leaf_not_reachable`, `missing_node`, `missing_source_url`
- Verification binding
  - Deterministic filtering/sorting of jobs by leaf and `(queueSequence, jobId)`
  - Canonical `jobHash` included per job via verification-flow hash contract
- Reproducible eval script
  - `scripts/eval-leaf-detail.mjs`
  - `npm run eval:leaf-detail -- <lean-project> --include=... --leaf=...`
- Tests
  - `tests/leaf-detail.test.ts`
- Docs/exports
  - `docs/leaf-detail.md`
  - `src/index.ts`, `README.md`, `package.json`

## Why this is leverageful
- Provides the exact deterministic payload needed by #16 UI panel work without coupling to a specific frontend framework.
- Bridges #9/#25 tree output and #17 verification history into one provenance-first leaf view.
- Makes missing source deep links explicit diagnostics instead of hidden failures.

## Validation
- `npm test` -> `77 passed`
- `npm run build` -> pass
- `npm run eval:leaf-detail -- tests/fixtures/lean-project --include=Verity` -> pass
- `npm run eval:leaf-detail -- /workspaces/mission-1ee8868c/verity --include=Verity --include=Compiler/ContractSpec.lean` -> pass

## Real Verity run result (example)
- `leafCount=1152`
- `treeNodeCount=1559`
- `detailOk=true`
- `provenanceDepth=7`
- deterministic `leafDetailHash` emitted

## Remaining blockers after this PR
1. Wire this contract into the interactive tree/leaf panel UI (#15/#16).
2. Add source URL resolver policy for non-GitHub/local projects to reduce `missing_source_url` warnings.
3. Connect panel actions to verification API endpoints from #17.

Closes #16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new exported contract that binds explanation-tree nodes to theorem leaves and verification-job history; correctness depends on deterministic path/diagnostic logic and consistent hashing, but it’s additive and covered by tests.
> 
> **Overview**
> Introduces a new exported `leaf-detail` module (`buildLeafDetailView`, `renderLeafDetailCanonical`, `computeLeafDetailHash`) that deterministically assembles a single-leaf payload: canonicalized theorem metadata, root-to-leaf provenance path, shareable references, and leaf-scoped verification job summaries including `jobHash`.
> 
> Adds a reproducible evaluation script (`eval:leaf-detail`), unit tests for determinism/diagnostics, and documentation/README updates to expose and validate the new contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f65505be2c79c636a00d736de6451521c1e1413. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->