### PR TITLE
feat: issue #18 deterministic tree quality evaluation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Inductive explanation trees from Lean specifications (Verity -> Yul case study).
 - Issue #17: browser-triggered verification workflow core with deterministic queue/status lifecycle, reproducibility contracts, and canonical ledger persistence.
 - Issue #17 follow-up: browser-callable verification HTTP API with deterministic route payloads, persisted ledger-backed job querying, and command-runner integration.
 - Issue #16: deterministic leaf-detail/provenance contract for theorem inspection, source linking/share references, and verification-job binding for browser panels.
+- Issue #18: deterministic faithfulness/simplicity evaluation harness with per-parent/per-depth quality metrics, threshold gating, and canonical report hashing.
 
 ## Local checks
 ```bash
@@ -29,6 +30,7 @@ npm run ingest:lean -- /path/to/lean-project
 npm run eval:domain-adapters
 npm run eval:tree-pipeline -- /path/to/lean-project --include=Verity --include=Compiler/ContractSpec.lean
 npm run eval:leaf-detail -- /path/to/lean-project --include=Verity --leaf=<leaf-id>
+npm run eval:quality -- /path/to/lean-project --include=Verity --include=Compiler/ContractSpec.lean
 npm run serve:verification
 ```
 
@@ -48,6 +50,7 @@ EXPLAIN_MD_LIVE_RPC_API_KEY=... npm run test:live:summary
 - [Inductive child grouping](docs/child-grouping.md)
 - [Parent summary pipeline](docs/summary-pipeline.md)
 - [Recursive tree builder](docs/tree-builder.md)
+- [Evaluation harness](docs/evaluation-harness.md)
 - [Pedagogical policy engine](docs/pedagogical-policy.md)
 - [Browser-triggered verification flow](docs/verification-flow.md)
 - [Verification HTTP API service](docs/verification-api.md)

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -1,0 +1,93 @@
+# Evaluation harness
+
+Issue #18 introduces deterministic quality scoring for generated explanation trees.
+
+## Goals
+- Measure parent-claim support against descendant evidence.
+- Track pedagogical quality metrics that are already enforced by the policy engine.
+- Emit canonical, hashable reports suitable for CI regression gates.
+
+## API
+- `evaluateExplanationTreeQuality(tree, config, options?)`
+  - Returns a machine-checkable `TreeQualityReport`.
+- `renderTreeQualityReportCanonical(report)`
+  - Stable JSON rendering for reproducible artifacts (normalizes `generatedAt`).
+- `computeTreeQualityReportHash(report)`
+  - SHA-256 hash of canonical report bytes.
+
+## Metrics
+- `unsupportedParentRate`
+  - Parent statements whose lexical claims are weakly supported by descendant vocabulary and allowed new terms.
+- `prerequisiteViolationRate`
+  - Parents with non-zero prerequisite-order violations from pre-summary policy diagnostics.
+- `policyViolationRate`
+  - Parents with any policy violation in pre- or post-summary diagnostics.
+- `meanComplexitySpread`
+  - Mean sibling complexity spread across parents.
+- `meanEvidenceCoverage`
+  - Mean child-coverage ratio for `evidence_refs`.
+- `meanVocabularyContinuity`
+  - Mean vocabulary continuity ratio from post-summary diagnostics.
+- `meanTermJumpRate`
+  - Mean ratio of introduced terms to meaningful parent tokens.
+
+Reports also include per-parent samples and per-depth aggregates.
+
+## Threshold gating
+The evaluator computes a threshold verdict (`thresholdPass`) with machine-readable failures:
+- `unsupported_parent_rate`
+- `prerequisite_violation_rate`
+- `policy_violation_rate`
+- `term_jump_rate`
+- `complexity_spread_mean`
+- `evidence_coverage_mean`
+- `vocabulary_continuity_mean`
+
+Defaults are deterministic and can be overridden in `options.thresholds`.
+
+## Human review rubric
+Use this rubric when manually spot-checking parent nodes flagged by the automated report:
+
+1. Entailment
+Score `0/1`: every parent claim is explicitly supported by child/descendant statements.
+2. Pedagogy progression
+Score `0/1`: prerequisite ideas appear before dependent claims in reading order.
+3. Complexity smoothness
+Score `0/1`: sibling explanations stay within a narrow difficulty band.
+4. Terminology discipline
+Score `0/1`: parent introduces only minimal new vocabulary relative to children.
+5. Source/provenance clarity
+Score `0/1`: reviewer can trace claim back to concrete leaves and source locations.
+
+Recommended policy: investigate any sample with rubric score `< 4`.
+
+## Reproducible CLI
+Run a full deterministic ingest->tree->quality pipeline:
+
+```bash
+npm run eval:quality -- /path/to/lean-project --include=Verity --include=Compiler/ContractSpec.lean
+```
+
+Optional threshold overrides:
+
+```bash
+npm run eval:quality -- /path/to/lean-project \
+  --max-unsupported-parent-rate=0.05 \
+  --min-vocabulary-continuity-mean=0.70
+```
+
+Exit codes:
+- `0`: tree validates and thresholds pass.
+- `2`: tree validity or threshold gate failed.
+- `1`: runtime error.
+
+## Verity benchmark examples
+- Loop/arithmetic/conditional-heavy subset:
+
+```bash
+npm run eval:quality -- /workspaces/mission-1ee8868c/verity \
+  --include=Verity/Proofs/Counter/Correctness.lean \
+  --include=Verity/Proofs/SimpleToken/Correctness.lean \
+  --include=Verity/Core.lean \
+  --include=Compiler/ContractSpec.lean
+```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eval:domain-adapters": "npm run -s build && node scripts/eval-domain-adapters.mjs",
     "eval:tree-pipeline": "npm run -s build && node scripts/eval-tree-pipeline.mjs",
     "eval:leaf-detail": "npm run -s build && node scripts/eval-leaf-detail.mjs",
+    "eval:quality": "npm run -s build && node scripts/eval-quality-harness.mjs",
     "serve:verification": "npm run -s build && node scripts/verification-server.mjs"
   },
   "devDependencies": {

--- a/scripts/eval-quality-harness.mjs
+++ b/scripts/eval-quality-harness.mjs
@@ -1,0 +1,166 @@
+import path from "node:path";
+import process from "node:process";
+import {
+  buildRecursiveExplanationTree,
+  computeTreeQualityReportHash,
+  evaluateExplanationTreeQuality,
+  ingestLeanProject,
+  mapLeanIngestionToTheoremLeaves,
+  mapTheoremLeavesToTreeLeaves,
+  normalizeConfig,
+  validateExplanationTree,
+} from "../dist/index.js";
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const cwd = process.cwd();
+
+  let projectRoot = cwd;
+  const includePaths = [];
+  const thresholdOverrides = {};
+
+  for (const arg of args) {
+    if (arg.startsWith("--include=")) {
+      includePaths.push(arg.slice("--include=".length));
+      continue;
+    }
+    if (arg.startsWith("--max-unsupported-parent-rate=")) {
+      thresholdOverrides.maxUnsupportedParentRate = Number.parseFloat(arg.slice("--max-unsupported-parent-rate=".length));
+      continue;
+    }
+    if (arg.startsWith("--max-prerequisite-violation-rate=")) {
+      thresholdOverrides.maxPrerequisiteViolationRate = Number.parseFloat(
+        arg.slice("--max-prerequisite-violation-rate=".length),
+      );
+      continue;
+    }
+    if (arg.startsWith("--max-policy-violation-rate=")) {
+      thresholdOverrides.maxPolicyViolationRate = Number.parseFloat(arg.slice("--max-policy-violation-rate=".length));
+      continue;
+    }
+    if (arg.startsWith("--max-term-jump-rate=")) {
+      thresholdOverrides.maxTermJumpRate = Number.parseFloat(arg.slice("--max-term-jump-rate=".length));
+      continue;
+    }
+    if (arg.startsWith("--max-complexity-spread-mean=")) {
+      thresholdOverrides.maxComplexitySpreadMean = Number.parseFloat(arg.slice("--max-complexity-spread-mean=".length));
+      continue;
+    }
+    if (arg.startsWith("--min-evidence-coverage-mean=")) {
+      thresholdOverrides.minEvidenceCoverageMean = Number.parseFloat(arg.slice("--min-evidence-coverage-mean=".length));
+      continue;
+    }
+    if (arg.startsWith("--min-vocabulary-continuity-mean=")) {
+      thresholdOverrides.minVocabularyContinuityMean = Number.parseFloat(arg.slice("--min-vocabulary-continuity-mean=".length));
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      projectRoot = path.resolve(cwd, arg);
+    }
+  }
+
+  return { projectRoot, includePaths, thresholdOverrides };
+}
+
+function extractChildren(prompt) {
+  const lines = prompt.split("\n");
+  const children = [];
+  for (const line of lines) {
+    const match = line.match(/^- id=([^\s]+)(?:\s+complexity=\d+)?\s+statement=(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    try {
+      children.push({ id: match[1], statement: JSON.parse(match[2]) });
+    } catch {
+      children.push({ id: match[1], statement: match[2] });
+    }
+  }
+
+  children.sort((left, right) => left.id.localeCompare(right.id));
+  return children;
+}
+
+function deterministicSummaryProvider() {
+  return {
+    generate: async (request) => {
+      const children = extractChildren(request.messages?.[1]?.content ?? "");
+      const evidenceRefs = children.map((child) => child.id);
+      const statement = children.map((child) => `(${child.statement})`).join(" and ");
+
+      return {
+        text: JSON.stringify({
+          parent_statement: statement,
+          why_true_from_children: statement,
+          new_terms_introduced: [],
+          complexity_score: 3,
+          abstraction_score: 3,
+          evidence_refs: evidenceRefs,
+          confidence: 0.99,
+        }),
+        model: "mock-deterministic",
+        finishReason: "stop",
+        raw: {},
+      };
+    },
+    stream: async function* () {
+      return;
+    },
+  };
+}
+
+async function main() {
+  const { projectRoot, includePaths, thresholdOverrides } = parseArgs(process.argv);
+  const ingestion = await ingestLeanProject(projectRoot, {
+    includePaths: includePaths.length > 0 ? includePaths : undefined,
+  });
+
+  const leaves = mapTheoremLeavesToTreeLeaves(mapLeanIngestionToTheoremLeaves(ingestion));
+  const config = normalizeConfig({
+    maxChildrenPerParent: 5,
+    complexityLevel: 3,
+    complexityBandWidth: 2,
+    termIntroductionBudget: 0,
+    proofDetailMode: "formal",
+  });
+
+  const started = Date.now();
+  const tree = await buildRecursiveExplanationTree(deterministicSummaryProvider(), {
+    leaves,
+    config,
+  });
+  const elapsedMs = Date.now() - started;
+
+  const validation = validateExplanationTree(tree, config.maxChildrenPerParent);
+  const report = evaluateExplanationTreeQuality(tree, config, { thresholds: thresholdOverrides });
+
+  const result = {
+    projectRoot,
+    includePaths,
+    ingestionRecords: ingestion.records.length,
+    ingestionWarnings: ingestion.warnings.length,
+    leafCount: leaves.length,
+    nodeCount: Object.keys(tree.nodes).length,
+    parentCount: report.metrics.parentCount,
+    maxDepth: tree.maxDepth,
+    treeValidationOk: validation.ok,
+    treeValidationIssueCount: validation.issues.length,
+    thresholdPass: report.thresholdPass,
+    thresholdFailureCount: report.thresholdFailures.length,
+    qualityReportHash: computeTreeQualityReportHash(report),
+    metrics: report.metrics,
+    thresholds: report.thresholds,
+    elapsedMs,
+  };
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!report.thresholdPass || !validation.ok) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`eval-quality-harness failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/evaluation-harness.ts
+++ b/src/evaluation-harness.ts
@@ -1,0 +1,530 @@
+import { createHash } from "node:crypto";
+import type { ExplanationConfig } from "./config-contract.js";
+import type { ExplanationTree } from "./tree-builder.js";
+import { stemToken, tokenizeNormalized } from "./text-normalization.js";
+
+const STOP_WORDS = new Set<string>([
+  "about",
+  "after",
+  "again",
+  "because",
+  "before",
+  "being",
+  "between",
+  "could",
+  "every",
+  "first",
+  "from",
+  "have",
+  "into",
+  "their",
+  "there",
+  "these",
+  "those",
+  "through",
+  "under",
+  "using",
+  "where",
+  "which",
+  "while",
+  "with",
+  "without",
+  "this",
+  "that",
+  "therefore",
+  "thus",
+]);
+
+const MIN_MEANINGFUL_TOKEN_LENGTH = 3;
+
+export interface TreeQualityThresholds {
+  maxUnsupportedParentRate: number;
+  maxPrerequisiteViolationRate: number;
+  maxPolicyViolationRate: number;
+  maxTermJumpRate: number;
+  maxComplexitySpreadMean: number;
+  minEvidenceCoverageMean: number;
+  minVocabularyContinuityMean: number;
+}
+
+export interface TreeQualityThresholdFailure {
+  code:
+    | "unsupported_parent_rate"
+    | "prerequisite_violation_rate"
+    | "policy_violation_rate"
+    | "term_jump_rate"
+    | "complexity_spread_mean"
+    | "evidence_coverage_mean"
+    | "vocabulary_continuity_mean";
+  message: string;
+  details: {
+    actual: number;
+    expected: number;
+    comparator: "<=" | ">=";
+  };
+}
+
+export interface ParentQualitySample {
+  parentId: string;
+  depth: number;
+  childCount: number;
+  complexitySpread: number;
+  prerequisiteOrderViolations: number;
+  evidenceCoverageRatio: number;
+  vocabularyContinuityRatio: number;
+  supportedClaimRatio: number;
+  introducedTermCount: number;
+  introducedTermRate: number;
+  policyViolationCount: number;
+}
+
+export interface DepthQualityMetrics {
+  depth: number;
+  parentCount: number;
+  unsupportedParentRate: number;
+  prerequisiteViolationRate: number;
+  policyViolationRate: number;
+  meanComplexitySpread: number;
+  meanEvidenceCoverage: number;
+  meanVocabularyContinuity: number;
+  meanTermJumpRate: number;
+}
+
+export interface TreeQualityMetrics {
+  parentCount: number;
+  unsupportedParentCount: number;
+  prerequisiteViolationParentCount: number;
+  policyViolationParentCount: number;
+  introducedTermOverflowParentCount: number;
+  unsupportedParentRate: number;
+  prerequisiteViolationRate: number;
+  policyViolationRate: number;
+  meanComplexitySpread: number;
+  maxComplexitySpread: number;
+  meanEvidenceCoverage: number;
+  meanVocabularyContinuity: number;
+  meanTermJumpRate: number;
+  supportCoverageFloor: number;
+}
+
+export interface EvaluateTreeQualityOptions {
+  thresholds?: Partial<TreeQualityThresholds>;
+}
+
+export interface TreeQualityReport {
+  rootId: string;
+  configHash: string;
+  generatedAt: string;
+  metrics: TreeQualityMetrics;
+  thresholds: TreeQualityThresholds;
+  thresholdPass: boolean;
+  thresholdFailures: TreeQualityThresholdFailure[];
+  parentSamples: ParentQualitySample[];
+  depthMetrics: DepthQualityMetrics[];
+}
+
+export function evaluateExplanationTreeQuality(
+  tree: ExplanationTree,
+  config: ExplanationConfig,
+  options: EvaluateTreeQualityOptions = {},
+): TreeQualityReport {
+  const supportCoverageFloor = computeSupportCoverageFloor(config);
+  const thresholds = normalizeThresholds(config, options.thresholds);
+  const parentSamples = collectParentSamples(tree, config, supportCoverageFloor);
+  const depthMetrics = buildDepthMetrics(parentSamples, supportCoverageFloor);
+  const metrics = aggregateMetrics(parentSamples, supportCoverageFloor);
+  const thresholdFailures = evaluateThresholds(metrics, thresholds);
+
+  return {
+    rootId: tree.rootId,
+    configHash: tree.configHash,
+    generatedAt: new Date().toISOString(),
+    metrics,
+    thresholds,
+    thresholdPass: thresholdFailures.length === 0,
+    thresholdFailures,
+    parentSamples,
+    depthMetrics,
+  };
+}
+
+export function renderTreeQualityReportCanonical(report: TreeQualityReport): string {
+  const canonical = canonicalizeReport(report);
+  return JSON.stringify({
+    ...canonical,
+    generatedAt: "<non-deterministic>",
+  });
+}
+
+export function computeTreeQualityReportHash(report: TreeQualityReport): string {
+  return createHash("sha256").update(renderTreeQualityReportCanonical(report)).digest("hex");
+}
+
+function canonicalizeReport(report: TreeQualityReport): TreeQualityReport {
+  return {
+    ...report,
+    parentSamples: report.parentSamples
+      .slice()
+      .sort((left, right) => left.parentId.localeCompare(right.parentId)),
+    depthMetrics: report.depthMetrics.slice().sort((left, right) => left.depth - right.depth),
+    thresholdFailures: report.thresholdFailures
+      .slice()
+      .sort((left, right) => left.code.localeCompare(right.code) || left.message.localeCompare(right.message)),
+  };
+}
+
+function collectParentSamples(
+  tree: ExplanationTree,
+  config: ExplanationConfig,
+  supportCoverageFloor: number,
+): ParentQualitySample[] {
+  const samples: ParentQualitySample[] = [];
+  const descendantVocabularyMemo = new Map<string, Set<string>>();
+
+  const parentNodes = Object.values(tree.nodes)
+    .filter((node) => node.kind === "parent")
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  for (const parentNode of parentNodes) {
+    const policyDiagnostics = tree.policyDiagnosticsByParent[parentNode.id] ?? parentNode.policyDiagnostics;
+    const childCount = parentNode.childIds.length;
+
+    const complexitySpread = policyDiagnostics?.preSummary.metrics.complexitySpread ?? 0;
+    const prerequisiteOrderViolations = policyDiagnostics?.preSummary.metrics.prerequisiteOrderViolations ?? 0;
+    const evidenceCoverageRatio =
+      policyDiagnostics?.postSummary.metrics.evidenceCoverageRatio ??
+      computeDirectEvidenceCoverageRatio(parentNode.childIds, parentNode.evidenceRefs);
+    const vocabularyContinuityRatio = policyDiagnostics?.postSummary.metrics.vocabularyContinuityRatio ?? 1;
+    const policyViolationCount =
+      (policyDiagnostics?.preSummary.violations.length ?? 0) + (policyDiagnostics?.postSummary.violations.length ?? 0);
+
+    const parentTokens = meaningfulStems(parentNode.statement);
+    const descendantVocabulary = collectDescendantVocabulary(tree, parentNode.id, descendantVocabularyMemo);
+    const allowedNewTerms = new Set(meaningfulStems((parentNode.newTermsIntroduced ?? []).join(" ")));
+
+    const supportedTokens = parentTokens.filter((token) => descendantVocabulary.has(token) || allowedNewTerms.has(token));
+    const supportedClaimRatio = parentTokens.length === 0 ? 1 : supportedTokens.length / parentTokens.length;
+
+    const introducedTermCount = (parentNode.newTermsIntroduced ?? []).length;
+    const introducedTermRate = parentTokens.length === 0 ? 0 : introducedTermCount / parentTokens.length;
+
+    samples.push({
+      parentId: parentNode.id,
+      depth: parentNode.depth,
+      childCount,
+      complexitySpread,
+      prerequisiteOrderViolations,
+      evidenceCoverageRatio,
+      vocabularyContinuityRatio,
+      supportedClaimRatio,
+      introducedTermCount,
+      introducedTermRate,
+      policyViolationCount,
+    });
+  }
+
+  return samples;
+}
+
+function aggregateMetrics(samples: ParentQualitySample[], supportCoverageFloor: number): TreeQualityMetrics {
+  if (samples.length === 0) {
+    return {
+      parentCount: 0,
+      unsupportedParentCount: 0,
+      prerequisiteViolationParentCount: 0,
+      policyViolationParentCount: 0,
+      introducedTermOverflowParentCount: 0,
+      unsupportedParentRate: 0,
+      prerequisiteViolationRate: 0,
+      policyViolationRate: 0,
+      meanComplexitySpread: 0,
+      maxComplexitySpread: 0,
+      meanEvidenceCoverage: 1,
+      meanVocabularyContinuity: 1,
+      meanTermJumpRate: 0,
+      supportCoverageFloor,
+    };
+  }
+
+  let unsupportedParentCount = 0;
+  let prerequisiteViolationParentCount = 0;
+  let policyViolationParentCount = 0;
+  let introducedTermOverflowParentCount = 0;
+
+  let sumComplexitySpread = 0;
+  let maxComplexitySpread = 0;
+  let sumEvidenceCoverage = 0;
+  let sumVocabularyContinuity = 0;
+  let sumTermJumpRate = 0;
+
+  for (const sample of samples) {
+    if (sample.supportedClaimRatio < supportCoverageFloor) {
+      unsupportedParentCount += 1;
+    }
+    if (sample.prerequisiteOrderViolations > 0) {
+      prerequisiteViolationParentCount += 1;
+    }
+    if (sample.policyViolationCount > 0) {
+      policyViolationParentCount += 1;
+    }
+    if (sample.introducedTermRate > 1) {
+      introducedTermOverflowParentCount += 1;
+    }
+
+    sumComplexitySpread += sample.complexitySpread;
+    maxComplexitySpread = Math.max(maxComplexitySpread, sample.complexitySpread);
+    sumEvidenceCoverage += sample.evidenceCoverageRatio;
+    sumVocabularyContinuity += sample.vocabularyContinuityRatio;
+    sumTermJumpRate += sample.introducedTermRate;
+  }
+
+  const denominator = samples.length;
+
+  return {
+    parentCount: denominator,
+    unsupportedParentCount,
+    prerequisiteViolationParentCount,
+    policyViolationParentCount,
+    introducedTermOverflowParentCount,
+    unsupportedParentRate: unsupportedParentCount / denominator,
+    prerequisiteViolationRate: prerequisiteViolationParentCount / denominator,
+    policyViolationRate: policyViolationParentCount / denominator,
+    meanComplexitySpread: sumComplexitySpread / denominator,
+    maxComplexitySpread,
+    meanEvidenceCoverage: sumEvidenceCoverage / denominator,
+    meanVocabularyContinuity: sumVocabularyContinuity / denominator,
+    meanTermJumpRate: sumTermJumpRate / denominator,
+    supportCoverageFloor,
+  };
+}
+
+function buildDepthMetrics(samples: ParentQualitySample[], supportCoverageFloor: number): DepthQualityMetrics[] {
+  const byDepth = new Map<number, ParentQualitySample[]>();
+  for (const sample of samples) {
+    const current = byDepth.get(sample.depth) ?? [];
+    current.push(sample);
+    byDepth.set(sample.depth, current);
+  }
+
+  return Array.from(byDepth.entries())
+    .sort((left, right) => left[0] - right[0])
+    .map(([depth, depthSamples]) => {
+      const aggregate = aggregateMetrics(depthSamples, supportCoverageFloor);
+      return {
+        depth,
+        parentCount: aggregate.parentCount,
+        unsupportedParentRate: aggregate.unsupportedParentRate,
+        prerequisiteViolationRate: aggregate.prerequisiteViolationRate,
+        policyViolationRate: aggregate.policyViolationRate,
+        meanComplexitySpread: aggregate.meanComplexitySpread,
+        meanEvidenceCoverage: aggregate.meanEvidenceCoverage,
+        meanVocabularyContinuity: aggregate.meanVocabularyContinuity,
+        meanTermJumpRate: aggregate.meanTermJumpRate,
+      };
+    });
+}
+
+function evaluateThresholds(metrics: TreeQualityMetrics, thresholds: TreeQualityThresholds): TreeQualityThresholdFailure[] {
+  const failures: TreeQualityThresholdFailure[] = [];
+
+  if (metrics.unsupportedParentRate > thresholds.maxUnsupportedParentRate) {
+    failures.push({
+      code: "unsupported_parent_rate",
+      message: "Unsupported parent rate exceeded threshold.",
+      details: {
+        actual: metrics.unsupportedParentRate,
+        expected: thresholds.maxUnsupportedParentRate,
+        comparator: "<=",
+      },
+    });
+  }
+
+  if (metrics.prerequisiteViolationRate > thresholds.maxPrerequisiteViolationRate) {
+    failures.push({
+      code: "prerequisite_violation_rate",
+      message: "Prerequisite-order violation rate exceeded threshold.",
+      details: {
+        actual: metrics.prerequisiteViolationRate,
+        expected: thresholds.maxPrerequisiteViolationRate,
+        comparator: "<=",
+      },
+    });
+  }
+
+  if (metrics.policyViolationRate > thresholds.maxPolicyViolationRate) {
+    failures.push({
+      code: "policy_violation_rate",
+      message: "Policy-violation rate exceeded threshold.",
+      details: {
+        actual: metrics.policyViolationRate,
+        expected: thresholds.maxPolicyViolationRate,
+        comparator: "<=",
+      },
+    });
+  }
+
+  if (metrics.meanTermJumpRate > thresholds.maxTermJumpRate) {
+    failures.push({
+      code: "term_jump_rate",
+      message: "Mean term-introduction jump rate exceeded threshold.",
+      details: {
+        actual: metrics.meanTermJumpRate,
+        expected: thresholds.maxTermJumpRate,
+        comparator: "<=",
+      },
+    });
+  }
+
+  if (metrics.meanComplexitySpread > thresholds.maxComplexitySpreadMean) {
+    failures.push({
+      code: "complexity_spread_mean",
+      message: "Mean sibling complexity spread exceeded threshold.",
+      details: {
+        actual: metrics.meanComplexitySpread,
+        expected: thresholds.maxComplexitySpreadMean,
+        comparator: "<=",
+      },
+    });
+  }
+
+  if (metrics.meanEvidenceCoverage < thresholds.minEvidenceCoverageMean) {
+    failures.push({
+      code: "evidence_coverage_mean",
+      message: "Mean evidence coverage dropped below threshold.",
+      details: {
+        actual: metrics.meanEvidenceCoverage,
+        expected: thresholds.minEvidenceCoverageMean,
+        comparator: ">=",
+      },
+    });
+  }
+
+  if (metrics.meanVocabularyContinuity < thresholds.minVocabularyContinuityMean) {
+    failures.push({
+      code: "vocabulary_continuity_mean",
+      message: "Mean vocabulary continuity dropped below threshold.",
+      details: {
+        actual: metrics.meanVocabularyContinuity,
+        expected: thresholds.minVocabularyContinuityMean,
+        comparator: ">=",
+      },
+    });
+  }
+
+  return failures;
+}
+
+function normalizeThresholds(config: ExplanationConfig, overrides?: Partial<TreeQualityThresholds>): TreeQualityThresholds {
+  const defaults: TreeQualityThresholds = {
+    maxUnsupportedParentRate: 0.1,
+    maxPrerequisiteViolationRate: 0,
+    maxPolicyViolationRate: 0,
+    maxTermJumpRate: 0.35,
+    maxComplexitySpreadMean: config.complexityBandWidth,
+    minEvidenceCoverageMean: 1,
+    minVocabularyContinuityMean: computeVocabularyContinuityThreshold(config),
+  };
+
+  return {
+    maxUnsupportedParentRate: clampRate(overrides?.maxUnsupportedParentRate ?? defaults.maxUnsupportedParentRate),
+    maxPrerequisiteViolationRate: clampRate(overrides?.maxPrerequisiteViolationRate ?? defaults.maxPrerequisiteViolationRate),
+    maxPolicyViolationRate: clampRate(overrides?.maxPolicyViolationRate ?? defaults.maxPolicyViolationRate),
+    maxTermJumpRate: clampRate(overrides?.maxTermJumpRate ?? defaults.maxTermJumpRate),
+    maxComplexitySpreadMean: clampSpread(
+      overrides?.maxComplexitySpreadMean ?? defaults.maxComplexitySpreadMean,
+      config.complexityBandWidth,
+    ),
+    minEvidenceCoverageMean: clampRate(overrides?.minEvidenceCoverageMean ?? defaults.minEvidenceCoverageMean),
+    minVocabularyContinuityMean: clampRate(overrides?.minVocabularyContinuityMean ?? defaults.minVocabularyContinuityMean),
+  };
+}
+
+function clampRate(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function clampSpread(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(0, value);
+}
+
+function computeSupportCoverageFloor(config: ExplanationConfig): number {
+  const audienceBump = config.audienceLevel === "expert" ? 0.05 : config.audienceLevel === "novice" ? -0.05 : 0;
+  const proofBump = config.proofDetailMode === "formal" ? 0.1 : config.proofDetailMode === "minimal" ? -0.05 : 0;
+  const raw = 0.5 + audienceBump + proofBump;
+  return Math.max(0.35, Math.min(0.75, raw));
+}
+
+function computeVocabularyContinuityThreshold(config: ExplanationConfig): number {
+  const proofFloor = config.proofDetailMode === "formal" ? 0.7 : config.proofDetailMode === "balanced" ? 0.6 : 0.5;
+  const audienceDelta = config.audienceLevel === "novice" ? -0.05 : config.audienceLevel === "expert" ? 0.05 : 0;
+  return Math.max(0.4, Math.min(0.8, proofFloor + audienceDelta));
+}
+
+function collectDescendantVocabulary(
+  tree: ExplanationTree,
+  nodeId: string,
+  memo: Map<string, Set<string>>,
+): Set<string> {
+  const cached = memo.get(nodeId);
+  if (cached) {
+    return cached;
+  }
+
+  const node = tree.nodes[nodeId];
+  if (!node) {
+    memo.set(nodeId, new Set<string>());
+    return memo.get(nodeId) as Set<string>;
+  }
+
+  const combined = new Set<string>();
+  for (const childId of node.childIds) {
+    const child = tree.nodes[childId];
+    if (!child) {
+      continue;
+    }
+
+    for (const token of meaningfulStems(child.statement)) {
+      combined.add(token);
+    }
+
+    const descendantTokens = collectDescendantVocabulary(tree, childId, memo);
+    for (const token of descendantTokens) {
+      combined.add(token);
+    }
+  }
+
+  memo.set(nodeId, combined);
+  return combined;
+}
+
+function computeDirectEvidenceCoverageRatio(childIds: string[], evidenceRefs: string[]): number {
+  if (childIds.length === 0) {
+    return 1;
+  }
+
+  const evidenceSet = new Set(evidenceRefs);
+  let covered = 0;
+
+  for (const childId of childIds) {
+    if (evidenceSet.has(childId)) {
+      covered += 1;
+    }
+  }
+
+  return covered / childIds.length;
+}
+
+function meaningfulStems(text: string): string[] {
+  const rawTokens = tokenizeNormalized(text);
+  const stems = rawTokens
+    .map((token) => stemToken(token))
+    .filter((token) => token.length >= MIN_MEANINGFUL_TOKEN_LENGTH && !STOP_WORDS.has(token));
+
+  return Array.from(new Set(stems));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from "./openai-provider.js";
 export * from "./summary-pipeline.js";
 export * from "./tree-builder.js";
 export * from "./leaf-detail.js";
+export * from "./evaluation-harness.js";
 export * from "./verification-flow.js";
 export * from "./verification-api.js";
 export * from "./pedagogical-policy.js";

--- a/tests/evaluation-harness.test.ts
+++ b/tests/evaluation-harness.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { normalizeConfig } from "../src/config-contract.js";
+import {
+  computeTreeQualityReportHash,
+  evaluateExplanationTreeQuality,
+  renderTreeQualityReportCanonical,
+  type TreeQualityReport,
+} from "../src/evaluation-harness.js";
+import type { ExplanationTree } from "../src/tree-builder.js";
+
+function buildFixtureTree(): ExplanationTree {
+  return {
+    rootId: "parent:1",
+    leafIds: ["leaf:a", "leaf:b"],
+    configHash: "config-hash",
+    groupPlan: [
+      {
+        depth: 1,
+        index: 0,
+        inputNodeIds: ["leaf:a", "leaf:b"],
+        outputNodeId: "parent:1",
+        complexitySpread: 0,
+      },
+    ],
+    groupingDiagnostics: [
+      {
+        depth: 1,
+        orderedNodeIds: ["leaf:a", "leaf:b"],
+        complexitySpreadByGroup: [0],
+        warnings: [],
+      },
+    ],
+    policyDiagnosticsByParent: {
+      "parent:1": {
+        depth: 1,
+        groupIndex: 0,
+        retriesUsed: 0,
+        preSummary: {
+          ok: true,
+          violations: [],
+          metrics: {
+            complexitySpread: 0,
+            prerequisiteOrderViolations: 0,
+            introducedTermCount: 0,
+            evidenceCoverageRatio: 1,
+            vocabularyContinuityRatio: 1,
+            vocabularyContinuityFloor: 0.7,
+          },
+        },
+        postSummary: {
+          ok: true,
+          violations: [],
+          metrics: {
+            complexitySpread: 0,
+            prerequisiteOrderViolations: 0,
+            introducedTermCount: 0,
+            evidenceCoverageRatio: 1,
+            vocabularyContinuityRatio: 1,
+            vocabularyContinuityFloor: 0.7,
+          },
+        },
+      },
+    },
+    maxDepth: 1,
+    nodes: {
+      "leaf:a": {
+        id: "leaf:a",
+        kind: "leaf",
+        statement: "loop counter increments",
+        childIds: [],
+        depth: 0,
+        complexityScore: 2,
+        evidenceRefs: ["leaf:a"],
+      },
+      "leaf:b": {
+        id: "leaf:b",
+        kind: "leaf",
+        statement: "counter remains bounded",
+        childIds: [],
+        depth: 0,
+        complexityScore: 2,
+        evidenceRefs: ["leaf:b"],
+      },
+      "parent:1": {
+        id: "parent:1",
+        kind: "parent",
+        statement: "loop counter increments and remains bounded",
+        childIds: ["leaf:a", "leaf:b"],
+        depth: 1,
+        complexityScore: 2,
+        abstractionScore: 2,
+        confidence: 0.99,
+        whyTrueFromChildren: "children imply the parent",
+        newTermsIntroduced: [],
+        evidenceRefs: ["leaf:a", "leaf:b"],
+      },
+    },
+  };
+}
+
+function cloneWithTimestamp(report: TreeQualityReport, timestamp: string): TreeQualityReport {
+  return {
+    ...report,
+    generatedAt: timestamp,
+  };
+}
+
+describe("evaluation-harness", () => {
+  it("produces canonical render and stable hash independent of sample ordering", () => {
+    const config = normalizeConfig({ proofDetailMode: "formal", audienceLevel: "expert" });
+    const report = evaluateExplanationTreeQuality(buildFixtureTree(), config);
+
+    const shuffled: TreeQualityReport = {
+      ...report,
+      generatedAt: report.generatedAt,
+      parentSamples: report.parentSamples.slice().reverse(),
+      depthMetrics: report.depthMetrics.slice().reverse(),
+      thresholdFailures: report.thresholdFailures.slice().reverse(),
+    };
+
+    expect(renderTreeQualityReportCanonical(report)).toBe(renderTreeQualityReportCanonical(shuffled));
+    expect(computeTreeQualityReportHash(report)).toBe(computeTreeQualityReportHash(shuffled));
+  });
+
+  it("flags unsupported parent statements when claim tokens are not in descendants", () => {
+    const tree = buildFixtureTree();
+    tree.nodes["parent:1"].statement = "cryptographic signature guarantees liveness";
+    tree.nodes["parent:1"].newTermsIntroduced = [];
+
+    const config = normalizeConfig({ proofDetailMode: "formal", audienceLevel: "expert" });
+    const report = evaluateExplanationTreeQuality(tree, config, {
+      thresholds: {
+        maxUnsupportedParentRate: 0,
+      },
+    });
+
+    expect(report.metrics.unsupportedParentCount).toBe(1);
+    expect(report.metrics.unsupportedParentRate).toBe(1);
+    expect(report.thresholdPass).toBe(false);
+    expect(report.thresholdFailures.some((failure) => failure.code === "unsupported_parent_rate")).toBe(true);
+  });
+
+  it("fails threshold gates for prerequisite and policy violations", () => {
+    const tree = buildFixtureTree();
+    tree.policyDiagnosticsByParent["parent:1"] = {
+      ...tree.policyDiagnosticsByParent["parent:1"],
+      preSummary: {
+        ...tree.policyDiagnosticsByParent["parent:1"].preSummary,
+        ok: false,
+        violations: [{ code: "prerequisite_order", message: "ordering failure" }],
+        metrics: {
+          ...tree.policyDiagnosticsByParent["parent:1"].preSummary.metrics,
+          prerequisiteOrderViolations: 1,
+          complexitySpread: 3,
+        },
+      },
+      postSummary: {
+        ...tree.policyDiagnosticsByParent["parent:1"].postSummary,
+        ok: false,
+        violations: [{ code: "evidence_coverage", message: "coverage failure" }],
+        metrics: {
+          ...tree.policyDiagnosticsByParent["parent:1"].postSummary.metrics,
+          evidenceCoverageRatio: 0.5,
+          vocabularyContinuityRatio: 0.5,
+        },
+      },
+    };
+
+    const config = normalizeConfig({ proofDetailMode: "formal", audienceLevel: "intermediate", complexityBandWidth: 1 });
+    const report = evaluateExplanationTreeQuality(tree, config);
+
+    expect(report.metrics.prerequisiteViolationRate).toBe(1);
+    expect(report.metrics.policyViolationRate).toBe(1);
+    expect(report.metrics.meanComplexitySpread).toBe(3);
+    expect(report.metrics.meanEvidenceCoverage).toBe(0.5);
+    expect(report.thresholdPass).toBe(false);
+    expect(report.thresholdFailures.map((failure) => failure.code)).toContain("prerequisite_violation_rate");
+    expect(report.thresholdFailures.map((failure) => failure.code)).toContain("policy_violation_rate");
+    expect(report.thresholdFailures.map((failure) => failure.code)).toContain("complexity_spread_mean");
+    expect(report.thresholdFailures.map((failure) => failure.code)).toContain("evidence_coverage_mean");
+  });
+
+  it("ignores generatedAt in canonical render/hash so report identity is reproducible", () => {
+    const config = normalizeConfig();
+    const report = evaluateExplanationTreeQuality(buildFixtureTree(), config);
+
+    const left = cloneWithTimestamp(report, "2026-02-26T00:00:00.000Z");
+    const right = cloneWithTimestamp(report, "2026-02-27T00:00:00.000Z");
+
+    expect(renderTreeQualityReportCanonical(left)).toBe(renderTreeQualityReportCanonical(right));
+    expect(computeTreeQualityReportHash(left)).toBe(computeTreeQualityReportHash(right));
+  });
+});


### PR DESCRIPTION
## Summary
Implements a deterministic quality-evaluation harness for explanation trees (issue #18), with machine-checkable faithfulness/simplicity metrics, canonical report hashing, and threshold gating for regression checks.

## What was implemented
- New module: `src/evaluation-harness.ts`
  - `evaluateExplanationTreeQuality(tree, config, options?)`
  - `renderTreeQualityReportCanonical(report)`
  - `computeTreeQualityReportHash(report)`
- Deterministic metrics:
  - unsupported parent-claim rate from descendant lexical support
  - prerequisite-order violation rate
  - policy-violation rate
  - complexity spread mean/max
  - evidence coverage mean
  - vocabulary continuity mean
  - term-jump rate
  - per-parent samples and per-depth aggregates
- Threshold gate + machine-readable failure codes for CI/regression usage.
- Reproducible CLI script:
  - `scripts/eval-quality-harness.mjs`
  - `npm run eval:quality -- <lean-project> --include=...`
  - exits non-zero on validation/threshold failure (`2`) and runtime errors (`1`)
- Tests:
  - `tests/evaluation-harness.test.ts`
- Docs/spec:
  - `docs/evaluation-harness.md`
  - `README.md`, `package.json`, `src/index.ts`

## Determinism and auditability
- Report hash is derived from canonical JSON ordering.
- Non-deterministic `generatedAt` is normalized in canonical rendering so equal content yields equal hash.
- Threshold failures are explicit structured objects (code + comparator + expected/actual).

## Validation
- `npm test` -> pass (`77/77`)
- `npm run build` -> pass
- `npm run eval:quality -- tests/fixtures/lean-project --include=Verity` -> pass
- `npm run eval:quality -- /workspaces/mission-1ee8868c/verity --include=Verity/Proofs/Counter/Correctness.lean --include=Verity/Proofs/SimpleToken/Correctness.lean --include=Verity/Core.lean --include=Compiler/ContractSpec.lean` -> pass

## Verity benchmark result (example)
- `ingestionRecords=265`
- `leafCount=265`
- `parentCount=77`
- `treeValidationOk=true`
- `thresholdPass=true`
- `qualityReportHash=dbeb399b30c41f6dd04fd39c71ce39f0ae0aa1055fee0c20ce9fe7c910ab5449`

## What remains for full #18 closure
1. Wire `npm run eval:quality` into CI workflow once issue #21 CI pipeline is finalized.
2. Add broader benchmark presets for additional Verity spec families.

Refs #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new evaluation/reporting module plus a CLI entrypoint and docs; it mostly introduces new code paths and exports with minimal impact on existing tree-building behavior.
> 
> **Overview**
> Introduces a deterministic explanation-tree *quality evaluation harness* (`evaluateExplanationTreeQuality`) that computes per-parent/per-depth metrics (support coverage, policy/prerequisite violations, evidence/vocabulary continuity, complexity spread, term-jump rate) and applies configurable threshold gating with structured failure codes.
> 
> Adds canonical report rendering and SHA-256 hashing (normalizing `generatedAt` and sorting samples) for reproducible regression artifacts, plus a new `npm run eval:quality` CLI script that runs ingest → build → validate → evaluate and exits `2` on validation/threshold failures. Documentation, index exports, and Vitest coverage for determinism/threshold behavior are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f88bd34df71c9590fa3ccadfb1e3e71aa36e8f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->