### PR TITLE
Issue #12: deterministic blocked-subtree insertion scheduler for addition deltas

### DIFF
--- a/apps/web/lib/proof-cache-benchmark.ts
+++ b/apps/web/lib/proof-cache-benchmark.ts
@@ -64,8 +64,13 @@ export interface ProofCacheBenchmarkReport {
       afterChangeDiagnostics: string[];
       afterChangeAdditionRecovery?: {
         recoveryMode: "insertion" | "regeneration";
+        insertionFrontierCount: number;
+        insertionMergeParentCount: number;
         addedLeafCount: number;
         insertedParentCount: number;
+        insertionScheduledAttachmentCount: number;
+        insertionRecomputedAncestorCount: number;
+        insertionStrategy: "edge_connector_ancestor_recompute" | "regeneration";
         reusableParentSummaryCount: number;
         reusedParentSummaryCount: number;
         reusedParentSummaryByGroundingCount: number;
@@ -477,8 +482,16 @@ function extractTopologyAdditionRecoveryDiagnostics(
     recoveryMode: (additionRecovery.details.recoveryMode === "insertion" ? "insertion" : "regeneration") as
       | "insertion"
       | "regeneration",
+    insertionFrontierCount: Number(additionRecovery.details.insertionFrontierCount ?? 0),
+    insertionMergeParentCount: Number(additionRecovery.details.insertionMergeParentCount ?? 0),
     addedLeafCount: Number(additionRecovery.details.addedLeafCount ?? 0),
     insertedParentCount: Number(additionRecovery.details.insertedParentCount ?? 0),
+    insertionScheduledAttachmentCount: Number(additionRecovery.details.insertionScheduledAttachmentCount ?? 0),
+    insertionRecomputedAncestorCount: Number(additionRecovery.details.insertionRecomputedAncestorCount ?? 0),
+    insertionStrategy:
+      additionRecovery.details.insertionStrategy === "edge_connector_ancestor_recompute"
+        ? "edge_connector_ancestor_recompute"
+        : "regeneration",
     reusableParentSummaryCount: Number(additionRecovery.details.reusableParentSummaryCount ?? 0),
     reusedParentSummaryCount: Number(additionRecovery.details.reusedParentSummaryCount ?? 0),
     reusedParentSummaryByGroundingCount: Number(additionRecovery.details.reusedParentSummaryByGroundingCount ?? 0),

--- a/apps/web/tests/proof-cache-benchmark.test.ts
+++ b/apps/web/tests/proof-cache-benchmark.test.ts
@@ -31,8 +31,23 @@ describe("proof cache benchmark", () => {
     );
     expect(report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.recoveryMode).toBe("insertion");
     expect((report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.addedLeafCount ?? 0) > 0).toBe(true);
+    expect((report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.insertionFrontierCount ?? 0) > 0).toBe(
+      true,
+    );
+    expect(
+      (report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.insertionMergeParentCount ?? 0) > 0,
+    ).toBe(true);
     expect((report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.insertedParentCount ?? 0) > 0).toBe(
       true,
+    );
+    expect(
+      (report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.insertionScheduledAttachmentCount ?? 0) > 0,
+    ).toBe(true);
+    expect(
+      (report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.insertionRecomputedAncestorCount ?? 0) >= 0,
+    ).toBe(true);
+    expect(report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.insertionStrategy).toBe(
+      "edge_connector_ancestor_recompute",
     );
     expect(
       report.scenarios.topologyShapeInvalidation.afterChangeAdditionRecovery?.additionRecoveryHash,

--- a/apps/web/tests/proof-service.test.ts
+++ b/apps/web/tests/proof-service.test.ts
@@ -516,7 +516,12 @@ describe("proof service", () => {
       );
       expect(additionDiagnostic?.details?.recoveryMode).toBe("insertion");
       expect((additionDiagnostic?.details?.addedLeafCount as number) > 0).toBe(true);
+      expect((additionDiagnostic?.details?.insertionFrontierCount as number) > 0).toBe(true);
+      expect((additionDiagnostic?.details?.insertionMergeParentCount as number) > 0).toBe(true);
       expect((additionDiagnostic?.details?.insertedParentCount as number) > 0).toBe(true);
+      expect((additionDiagnostic?.details?.insertionScheduledAttachmentCount as number) > 0).toBe(true);
+      expect((additionDiagnostic?.details?.insertionRecomputedAncestorCount as number) >= 0).toBe(true);
+      expect(additionDiagnostic?.details?.insertionStrategy).toBe("edge_connector_ancestor_recompute");
       expect((additionDiagnostic?.details?.reusableParentSummaryCount as number) >= 0).toBe(true);
       expect((additionDiagnostic?.details?.reusedParentSummaryCount as number) >= 0).toBe(true);
       expect(

--- a/docs/benchmarks/proof-cache-benchmark.json
+++ b/docs/benchmarks/proof-cache-benchmark.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-02-27T15:44:52.696Z",
+  "generatedAt": "2026-02-27T15:59:09.695Z",
   "proofId": "lean-verity-fixture",
   "configHash": "a75632c3c71bea58a13445a49951b87763ebd9e868fb4f51ac128e6c783e8af7",
   "requestHash": "3f46810b2ac7310b0662c6e01ba36ed7e2f53d0d01cd2f7653b72ffecf20dc0e",
-  "outcomeHash": "dc4787f26403032b068665c885da6b7dddfc981a1f3edcd0db108e83c62dd316",
+  "outcomeHash": "87e641499542cb6d8cd2672d089809846d4b4c476ac1ce5bf7c048ed3cf824db",
   "parameters": {
     "coldIterations": 3,
     "warmIterations": 3,
     "mutationTargetPath": "Verity/Core.lean"
   },
   "paths": {
-    "fixtureProjectRootHash": "dc70e107eeec519e24013b071468daa4f547297f22ef2429e9fcc35ee4906a0b",
-    "cacheDirHash": "a5a37487e4eaf90763afb37f0dae2cf378d4aab782a4b0ca1c9027a63c0067fd"
+    "fixtureProjectRootHash": "f59d02f853f5046c951f2ff470e2b49135df117a97b9794843bbf8caa0c688f9",
+    "cacheDirHash": "d084da011b22df01f27d2f28cea441621b9e4bb0b3655451b9a6ef75a9cc9272"
   },
   "scenarios": {
     "coldNoPersistentCache": {
@@ -22,10 +22,10 @@
         "miss",
         "miss"
       ],
-      "meanMs": 20.93,
-      "medianMs": 14.028,
-      "minMs": 5.429,
-      "maxMs": 43.334
+      "meanMs": 9.675,
+      "medianMs": 3.502,
+      "minMs": 3.059,
+      "maxMs": 22.464
     },
     "warmPersistentCache": {
       "iterations": 3,
@@ -34,10 +34,10 @@
         "hit",
         "hit"
       ],
-      "meanMs": 2.421,
-      "medianMs": 2.417,
-      "minMs": 2.321,
-      "maxMs": 2.523
+      "meanMs": 2.129,
+      "medianMs": 2.65,
+      "minMs": 1.072,
+      "maxMs": 2.664
     },
     "invalidation": {
       "beforeChangeStatus": "hit",
@@ -64,8 +64,13 @@
       ],
       "afterChangeAdditionRecovery": {
         "recoveryMode": "insertion",
+        "insertionFrontierCount": 1,
+        "insertionMergeParentCount": 1,
         "addedLeafCount": 1,
         "insertedParentCount": 1,
+        "insertionScheduledAttachmentCount": 1,
+        "insertionRecomputedAncestorCount": 0,
+        "insertionStrategy": "edge_connector_ancestor_recompute",
         "reusableParentSummaryCount": 0,
         "reusedParentSummaryCount": 0,
         "reusedParentSummaryByGroundingCount": 0,
@@ -73,8 +78,8 @@
         "generatedParentSummaryCount": 1,
         "skippedAmbiguousStatementSignatureReuseCount": 0,
         "skippedUnrebasableStatementSignatureReuseCount": 0,
-        "regenerationHash": "d7aa4293f31e7ae46e1952325f2a8d6075d7bc25b2612910cb01b764fcbb9199",
-        "additionRecoveryHash": "b248622da6eb93314b9382f76c1097daf1cc03b7c4afa960358fedb1b948d30a"
+        "regenerationHash": "4440e25ea5d078120d8bd479ad4daa660cc3a79897883f3947b8d5831236b794",
+        "additionRecoveryHash": "1de6d69ee5b69a6ffce6a01f90206494f7ee0a0ee97f2b0676e06dc6f561a54f"
       },
       "afterChangeTopologyPlan": {
         "fullRebuildRequired": true,
@@ -84,9 +89,9 @@
         "blockedDeclarationCount": 1,
         "planHash": "bf473238a71fde44ce12e50d3ed61ac949a2c27bf8d1037cc7d980b941c67c2f"
       },
-      "afterChangeSnapshotHash": "c0ca3e106e250bc2b795e83e34d6023d1df87fcc422175ebe7a4315c7f018001",
+      "afterChangeSnapshotHash": "766603237738fd2ace254740616864deb2818fd0678232dd5fac8ed695d264c7",
       "recoveryStatus": "hit",
-      "recoverySnapshotHash": "c0ca3e106e250bc2b795e83e34d6023d1df87fcc422175ebe7a4315c7f018001"
+      "recoverySnapshotHash": "766603237738fd2ace254740616864deb2818fd0678232dd5fac8ed695d264c7"
     },
     "mixedTopologyShapeInvalidation": {
       "beforeChangeStatus": "hit",

--- a/docs/proof-cache-api.md
+++ b/docs/proof-cache-api.md
@@ -73,7 +73,15 @@ Deterministic cache-reuse diagnostics for proof dataset generation.
   - if declaration shape changes are addition-only, deterministic subtree insertion runs first on cached topology and emits `cache_topology_addition_subtree_insertion_rebuild_hit`:
     - recovery mode: `recoveryMode="insertion"`
     - addition evidence: `addedLeafCount`
-    - insertion telemetry: `insertedParentCount`, `generatedParentSummaryCount`, `regenerationHash`
+    - insertion scheduler telemetry:
+      - `insertionStrategy="edge_connector_ancestor_recompute"`
+      - `insertionFrontierCount`
+      - `insertionMergeParentCount`
+      - `insertionScheduledAttachmentCount`
+      - `insertionRecomputedAncestorCount`
+      - `insertedParentCount`
+      - `generatedParentSummaryCount`
+      - `regenerationHash`
     - combined audit hash: `additionRecoveryHash`
   - if addition-only insertion preconditions fail, deterministic topology regeneration fallback runs and emits `cache_topology_addition_subtree_regeneration_rebuild_hit` with `recoveryMode="regeneration"` plus reuse telemetry.
   - if declaration shape changes are mixed (both additions and removals), deterministic two-stage recovery runs and emits `cache_topology_mixed_subtree_regeneration_rebuild_hit`:

--- a/docs/proof-cache-benchmark.md
+++ b/docs/proof-cache-benchmark.md
@@ -20,8 +20,13 @@ By default this writes:
   - expected diagnostics include `cache_topology_addition_subtree_insertion_rebuild_hit`, and `afterChangeTopologyPlan.topologyShapeChanged=true`.
   - `afterChangeAdditionRecovery` records deterministic addition-only recovery telemetry:
     - `recoveryMode`
+    - `insertionFrontierCount`
+    - `insertionMergeParentCount`
     - `addedLeafCount`
     - `insertedParentCount`
+    - `insertionScheduledAttachmentCount`
+    - `insertionRecomputedAncestorCount`
+    - `insertionStrategy`
     - `reusableParentSummaryCount`
     - `reusedParentSummaryCount`
     - `reusedParentSummaryByGroundingCount`


### PR DESCRIPTION
## Summary
Implements the next deterministic #12 slice: a **blocked-subtree insertion scheduler** for addition-only topology-shape deltas.

This replaces the previous coarse root-merge insertion path with a deterministic frontier scheduler that:
- partitions added declarations into connected frontiers,
- builds each frontier subtree independently,
- inserts each frontier by deterministic edge-connector attachment at a deterministic anchor on cached topology,
- recomputes only affected ancestor parents (instead of full topology regeneration).

## What Was Implemented
- `apps/web/lib/proof-service.ts`
  - addition-only recovery now emits `cache_topology_addition_subtree_insertion_rebuild_hit` from a deterministic blocked-subtree scheduler (`insertionStrategy="edge_connector_ancestor_recompute"`).
  - deterministic frontier partitioning and anchor selection (`resolveInsertionAnchorNodeId`).
  - deterministic per-frontier connector parent creation + explicit ancestor recompute queue.
  - auditable telemetry additions for insertion mode:
    - `insertionFrontierCount`
    - `insertionMergeParentCount`
    - `insertionScheduledAttachmentCount`
    - `insertionRecomputedAncestorCount`
    - `insertionStrategy`
  - canonical hash inputs updated so these scheduler fields are part of `regenerationHash`/`additionRecoveryHash` evidence.
- `apps/web/lib/proof-cache-benchmark.ts`
  - benchmark schema/extractors updated to capture the new insertion scheduler telemetry.
- Tests:
  - `apps/web/tests/proof-service.test.ts`
  - `apps/web/tests/proof-cache-benchmark.test.ts`
  - assertions added for scheduler telemetry and determinism.
- Docs/spec:
  - `docs/proof-cache-api.md`
  - `docs/proof-cache-benchmark.md`
  - telemetry and semantics documented.
- Artifact:
  - regenerated `docs/benchmarks/proof-cache-benchmark.json` with updated deterministic outcome hash.

## Validation
1. `npm run -s build` ✅
2. `npm run -s test` ✅ (`38 files`, `197 tests`)
3. `npm run -s web:lint` ✅
4. `npm run -s web:test` ✅ (`14 files`, `83 tests`)
5. `npm run -s web:bench:cache` ✅
6. `npm run -s eval:quality:ci` ✅ (`expectedOutcomeHash == actualOutcomeHash == 5413da91a55655a77ca29ce89a6b39d5890a4203da68a5b7341b2f9039f31fbf`)
7. `npm run -s web:typecheck` ⚠️ fails on pre-existing workspace drift (unrelated 3D deps + existing leaf-provenance/test typing gaps)
8. `npm run -s web:build` ⚠️ fails on pre-existing missing `@react-three/drei` / `@react-three/fiber`

## Deterministic Evidence
- Benchmark artifact: `docs/benchmarks/proof-cache-benchmark.json`
- `outcomeHash`: `87e641499542cb6d8cd2672d089809846d4b4c476ac1ce5bf7c048ed3cf824db`
- Topology-shape addition scenario now records scheduler evidence under `afterChangeAdditionRecovery`.

## What Remains
- This scheduler is deterministic and localized, but still uses connector-based insertion.
- Remaining #12 gap: broaden minimal insertion planning for more complex cross-frontier overlap patterns where an explicit multi-anchor/global minimal plan could further reduce recomputation.

## Why This Advances Lean/Verity Explanation Correctness + Usability
- Improves provenance-preserving incremental behavior by avoiding coarse full-shape regeneration on addition-only deltas.
- Keeps updates machine-checkable (hashes + explicit scheduler counters) and reproducible.
- Preserves pedagogy/config constraints by routing all newly generated/recomputed parents through existing policy gates (`maxChildrenPerParent`, prerequisite ordering, term budget, etc.).

Closes #12 progression slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the addition-only topology recovery path to build/attach multiple subtrees and recompute affected ancestors, which can change cache recovery behavior and hashes. Changes are deterministic and covered by updated tests/docs, but touch core cache recovery logic.
> 
> **Overview**
> Addition-only topology-shape recovery now uses a deterministic *frontier-based insertion scheduler* instead of a single coarse root merge: added leaves are partitioned into connected components, each component is built as its own subtree, deterministically attached at an anchor node, and only impacted ancestor parents are recomputed.
> 
> The insertion path now emits and hashes additional audit telemetry (e.g. `insertionFrontierCount`, `insertionMergeParentCount`, `insertionScheduledAttachmentCount`, `insertionRecomputedAncestorCount`, `insertionStrategy`), and benchmark extraction/tests/docs + the committed benchmark artifact are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cb69bcfa729e9446fc4d6936edbf72ab09315ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->